### PR TITLE
Fix SQL injection: parameterized queries for all CRUD operations

### DIFF
--- a/_rest_api_lambda_test/lambda_test_comprehensive.py
+++ b/_rest_api_lambda_test/lambda_test_comprehensive.py
@@ -580,26 +580,18 @@ lambda_test_execute({
     'expected_status': 404,
 })
 
-# GET-15: BUG — error path returns literal string "errorMsg" instead of variable.
-# rest_get_table.py:166: compose_rest_response('500', '', "errorMsg")
-# Trigger the SELECT error path (not DESC) by using a valid table with an
-# invalid sort column — DESC succeeds but the generated SQL fails.
-get15_response = safe_execute({
-    'test_name': 'GET-15: invalid sort column triggers SQL error returns 500',
+# GET-15: Invalid sort column is now validated before reaching SQL.
+# Previously this caused a SQL error (500) with a literal "errorMsg" string bug.
+# Now sort columns are validated against DESC results and rejected with 400.
+lambda_test_execute({
+    'test_name': 'GET-15: invalid sort column returns 400',
     'http_method': 'GET',
     'path': AREAS_PATH,
     'query_string_params': {'sort': 'BOGUS_COLUMN:asc'},
     'body': {},
     'context': {},
-    'expected_status': 500,
+    'expected_status': 400,
 })
-if get15_response and 'body' in get15_response:
-    has_literal = 'errorMsg' in get15_response['body']
-    record_check(
-        'GET-15b: BUG body contains literal "errorMsg" instead of actual error',
-        has_literal,
-        f'body: {get15_response["body"][:200]}'
-    )
 
 # GET-16: Double-encoding verification for GET table
 get16_response = lambda_test_execute({

--- a/rest_delete.py
+++ b/rest_delete.py
@@ -9,18 +9,20 @@ def rest_delete(delete_method, conn, table, body):
         return compose_rest_response(400, '', 'BAD REQUEST')
 
     # if multple key/value are provided in body default is to AND them together
-    where_clause = ' AND '.join(f"{key}={value}" for key, value in body.items())
-    
+    keys = list(body.keys())
+    values = list(body.values())
+    where_clause = ' AND '.join(f"{key} = %s" for key in keys)
+
     try:
         sql_statement = f"""
-            DELETE FROM {table} 
+            DELETE FROM {table}
             WHERE
                 {where_clause};
         """
         pretty_print_sql(sql_statement, delete_method)
 
         with conn.cursor() as cursor:
-            affected_rows = cursor.execute(sql_statement)
+            affected_rows = cursor.execute(sql_statement, tuple(values))
 
         if affected_rows == 0:
             errorMsg = f"Affected_rows = 0, 404 time"

--- a/rest_post.py
+++ b/rest_post.py
@@ -9,22 +9,22 @@ def rest_post(post_method, conn, table, body):
         return compose_rest_response(400, '', 'BAD REQUEST')
     varDump(body, 'body inside rest_post')
     # Assemble list of keys and values for use in SQL
-    sql_key_list = ', '.join(f'{key}' for key in body.keys())
-    sql_value_list = ', '.join(f"'{value}'" for value in body.values())
+    keys = list(body.keys())
+    values = [None if v == "NULL" else v for v in body.values()]
 
-    # NULL handling: mySQL requires no quotes around NULL values
-    sql_value_list = sql_value_list.replace("'NULL'", "NULL")
+    sql_key_list = ', '.join(keys)
+    placeholders = ', '.join(['%s'] * len(values))
 
     try:
         # insert row into table
         sql_statement = f"""
                     INSERT INTO {table} ({sql_key_list})
-                    VALUES ({sql_value_list});
+                    VALUES ({placeholders});
         """
         pretty_print_sql(sql_statement, post_method)
 
         with conn.cursor() as cursor:
-            affected_post_rows = cursor.execute(sql_statement)
+            affected_post_rows = cursor.execute(sql_statement, tuple(values))
 
         if affected_post_rows > 0:
             conn.commit()


### PR DESCRIPTION
## Summary
- Replace f-string SQL interpolation with pymysql `%s` parameterized queries across all REST modules (POST, PUT, DELETE, GET)
- Fixes SQL injection vulnerability and enables special characters (apostrophes, quotes, backslashes) in user input
- Add table name regex validation (`^[a-zA-Z_][a-zA-Z0-9_]*$`) as defense-in-depth
- Add sort column and direction validation in GET (returns 400 instead of letting bad SQL reach the database)
- Add filter_ts column validation against DESC results
- Convert NULL string sentinel (`"NULL"`) to Python `None` for proper pymysql handling

## Files changed
- `handler.py` — Added `re` import, `SAFE_NAME_RE` regex, table name validation, error check after `parse_path()`
- `rest_post.py` — Parameterized INSERT values with `%s` placeholders
- `rest_put.py` — Parameterized both single-record UPDATE (SET key=%s) and multi-record CASE/WHEN UPDATE
- `rest_delete.py` — Parameterized WHERE clause with `%s` placeholders
- `rest_get_table.py` — Parameterized equality, IN clause, and BETWEEN filters; added sort/filter_ts validation
- `_rest_api_lambda_test/lambda_test_darwin.py` — Added special character CUD lifecycle test (apostrophes, quotes, SQL injection attempt)
- `_rest_api_lambda_test/lambda_test_comprehensive.py` — Updated GET-15 test (sort validation now returns 400)

## Testing
- Lambda unit tests: 11/11 passing (original suite + special character lifecycle)
- Comprehensive API tests: 93/93 passing
- Production E2E: 35/35 passing against darwin.one

## Deploy notes
- Already deployed to AWS Lambda (RestApi-MySql-Lambda)
- Related PRs: Darwin (frontend blockApostrophe removal), Lambda-Cognito (parameterized INSERTs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)