### PR TITLE
Bulk import speed improvement

### DIFF
--- a/rest_post.py
+++ b/rest_post.py
@@ -119,7 +119,7 @@ def rest_post(post_method, conn, database, table, body, authenticated_user=None)
 
 
 def _rest_post_bulk(post_method, conn, table, body_list, authenticated_user):
-    """Insert multiple rows via single multi-value INSERT. Returns 201 with inserted count."""
+    """Insert multiple rows via single multi-value INSERT. Returns 201 with inserted count and first_id."""
 
     if not body_list:
         return compose_rest_response(400, '', 'BAD REQUEST')
@@ -147,7 +147,19 @@ def _rest_post_bulk(post_method, conn, table, body_list, authenticated_user):
         with conn.cursor() as cursor:
             cursor.execute(sql_statement, tuple(all_values))
 
-        return compose_rest_response(201, json.dumps({"inserted": len(body_list)}), 'CREATED')
+        # Retrieve first auto-increment ID from the multi-row INSERT.
+        # MySQL guarantees consecutive IDs for a single multi-value INSERT statement.
+        result = {"inserted": len(body_list)}
+        try:
+            with conn.cursor() as cursor:
+                cursor.execute("SELECT LAST_INSERT_ID()")
+                row = cursor.fetchone()
+                if row and row[0]:
+                    result["first_id"] = row[0]
+        except pymysql.Error:
+            pass  # Non-fatal: callers can fall back to individual inserts
+
+        return compose_rest_response(201, result, 'CREATED')
 
     except pymysql.Error as e:
         conn.rollback()

--- a/tests/test_crud_lifecycle.py
+++ b/tests/test_crud_lifecycle.py
@@ -489,6 +489,58 @@ class TestCRUDLifecycle:
         delete_resp = invoke('DELETE', '/darwin_dev/areas', body={'id': area_id})
         assert delete_resp['statusCode'] == 200
 
+    # -----------------------------------------------------------------------
+    # CRUD-10: Bulk POST returns first_id with consecutive IDs
+    # -----------------------------------------------------------------------
+
+    def test_bulk_post_returns_first_id(self, invoke, creator_fk, test_ids):
+        """CRUD-10: Bulk POST map_runs returns first_id and inserted count with consecutive IDs.
+
+        Tests the bulk POST enhancement that returns the first auto-increment ID:
+        - POST array of 3 map_runs
+        - Verify response contains first_id and inserted=3
+        - Verify each computed ID (first_id+0, +1, +2) resolves to a real row
+        - Cleanup: DELETE all 3 rows
+        """
+        # Step 1: Bulk POST 3 map_runs
+        runs = [
+            {
+                'run_id': 99000 + i,
+                'map_route_fk': 'NULL',
+                'start_time': f'2025-01-0{i+1}T12:00:00Z',
+                'run_time_sec': 3600,
+                'distance_mi': 10.5,
+                'source': 'test-bulk',
+                'creator_fk': creator_fk,
+            }
+            for i in range(3)
+        ]
+        resp = invoke('POST', '/darwin_dev/map_runs', body=runs)
+        assert resp['statusCode'] == 201, f"Expected 201, got {resp['statusCode']}"
+        body = json.loads(resp['body'])
+        # Handle potential double-encoding from compose_rest_response
+        if isinstance(body, str):
+            body = json.loads(body)
+        assert body['inserted'] == 3
+        assert 'first_id' in body, "Bulk POST response missing first_id"
+        first_id = body['first_id']
+        assert isinstance(first_id, int) and first_id > 0
+
+        # Step 2: GET each consecutive ID to verify they exist
+        for offset in range(3):
+            expected_id = first_id + offset
+            get_resp = invoke('GET', '/darwin_dev/map_runs', query={'id': str(expected_id)})
+            assert get_resp['statusCode'] == 200, \
+                f"Expected 200 for ID {expected_id}, got {get_resp['statusCode']}"
+            row = json.loads(get_resp['body'])
+            assert row[0]['id'] == expected_id, \
+                f"Expected id={expected_id}, got id={row[0]['id']}"
+            assert row[0]['source'] == 'test-bulk'
+
+        # Step 3: Cleanup — DELETE each row
+        for offset in range(3):
+            invoke('DELETE', '/darwin_dev/map_runs', body={'id': first_id + offset})
+
 
 class TestBulkDeleteByCreatorFk:
     """Verifies that DELETE with creator_fk body deletes all rows for the user.


### PR DESCRIPTION
## Summary
- `_rest_post_bulk` now returns `{inserted: N, first_id: X}` via LAST_INSERT_ID()
- Enables frontend to compute consecutive run IDs without per-row POST round-trips
- Fixed existing double-encoding in bulk POST response
- Additive change — backward-compatible (existing callers ignore first_id)

## Files changed
- `rest_post.py` — added LAST_INSERT_ID() query after multi-row INSERT, return first_id in response dict, fixed double-encoding
- `tests/test_crud_lifecycle.py` — added CRUD-10: bulk POST 3 map_runs, verify first_id and consecutive IDs

## Testing
- Lambda-Rest: 112/112 tests passing
- innodb_autoinc_lock_mode=2 verified on RDS — safe for simple inserts (contiguous block)

## Deploy notes
- Already deployed to production (RestApi-MySql-Lambda)
- Must be deployed before Darwin frontend PR

## References
- Darwin priority #1892
- Related PR: BillWilliams79/Darwin#318

🤖 Generated with [Claude Code](https://claude.com/claude-code)