### PR TITLE
Rename Priorities to Requirements

### DIFF
--- a/auth_utils.py
+++ b/auth_utils.py
@@ -23,7 +23,7 @@ def get_authenticated_user(event):
 # Tables that have a creator_fk column and must be scoped to the authenticated user
 CREATOR_FK_TABLES = frozenset({
     'domains', 'areas', 'tasks',
-    'projects', 'categories', 'priorities',
+    'projects', 'categories', 'requirements',
     'dev_servers', 'swarm_sessions', 'recurring_tasks',
     'map_routes', 'map_runs', 'map_views',
     'map_partners',


### PR DESCRIPTION
## Summary
- Updated CREATOR_FK_TABLES: 'priorities' → 'requirements' for creator_fk scoping

## References
- Darwin PR: https://github.com/BillWilliams79/Darwin/pull/327
- DarwinSQL PR: https://github.com/BillWilliams79/DarwinSQL/pull/37

🤖 Generated with [Claude Code](https://claude.com/claude-code)