### PR TITLE
Persist agent-context telemetry runs + render the actual-token view (multi-run, variable agent count)

### DIFF
--- a/auth_utils.py
+++ b/auth_utils.py
@@ -57,6 +57,10 @@ CREATOR_FK_TABLES = frozenset({
     # and architecture_documents each carry creator_fk. agent_documents and
     # agent_instructions are junctions with no creator_fk and stay out.
     'agents', 'instructions', 'architecture_documents',
+    # Req #3031 — agent context telemetry (migration 069). Both the run header
+    # and the per-agent rows carry creator_fk; scope generic passthrough to the
+    # authenticated user.
+    'agent_telemetry_runs', 'agent_telemetry_rows',
 })
 
 PROFILE_TABLE = 'profiles'


### PR DESCRIPTION
## Summary
- wip(Lambda-Rest): 2026-07-23T08:10:04Z
- chore: init swarm session feature/3031-persist-agent-context-telemetry-1

## Files changed
```
 auth_utils.py | 4 ++++
 1 file changed, 4 insertions(+)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)