### PR TITLE
Two stale backend test files fail on schema drift

### DIFF
--- a/tests/test_instructions.py
+++ b/tests/test_instructions.py
@@ -47,11 +47,19 @@ def instruction(invoke, creator_fk):
 class TestInstructionsCRUD:
 
     def test_crud_lifecycle(self, invoke, creator_fk):
-        """POST → PUT → GET → DELETE → GET 404 through the generic passthrough."""
+        """POST → PUT → GET → DELETE → GET 404 through the generic passthrough.
+
+        req #3061: this fixture used to round-trip a `sort_order` field, but
+        migration 072 (req #3063) dropped `instructions.sort_order` — the catalog
+        column that was always distinct from `agent_instructions.sort_order`, the
+        boot load order. The passthrough builds its column list from the body, so
+        the phantom key was a MySQL 1054, not a skipped field. The multi-column
+        PUT it was there to cover now round-trips `name`, which is the other
+        column the /agents/instructions UI edits.
+        """
         create = invoke('POST', '/darwin_dev/instructions', body={
             'name': f'pytest-{creator_fk}-lifecycle',
             'content': 'never fabricate a root cause',
-            'sort_order': '5',
             'creator_fk': creator_fk,
         })
         assert create['statusCode'] == 200
@@ -59,7 +67,8 @@ class TestInstructionsCRUD:
         assert row_id is not None
 
         update = invoke('PUT', '/darwin_dev/instructions', body=[
-            {'id': row_id, 'content': 'REVISED duty', 'sort_order': '9'},
+            {'id': row_id, 'content': 'REVISED duty',
+             'name': f'pytest-{creator_fk}-lifecycle-renamed'},
         ])
         assert update['statusCode'] in (200, 204)
 
@@ -67,7 +76,7 @@ class TestInstructionsCRUD:
         assert get['statusCode'] == 200
         row = json.loads(get['body'])[0]
         assert row['content'] == 'REVISED duty'
-        assert row['sort_order'] == 9
+        assert row['name'] == f'pytest-{creator_fk}-lifecycle-renamed'
 
         assert invoke('DELETE', '/darwin_dev/instructions',
                       body={'id': row_id})['statusCode'] == 200

--- a/tests/test_swarm_starts.py
+++ b/tests/test_swarm_starts.py
@@ -19,14 +19,22 @@ class TestSwarmStartsCRUD:
 
     def test_swarm_starts_crud_lifecycle(self, invoke, creator_fk):
         """POST create swarm_start → PUT update → GET verify → DELETE → GET 404."""
-        # Step 1: POST a swarm_start record
+        # Step 1: POST a swarm_start record.
+        # Every key below must be a real swarm_starts column — the passthrough
+        # builds the INSERT column list straight from the body, so a phantom key
+        # is a MySQL 1054, not a skipped field. (req #3061: this fixture carried
+        # `category_filter` and `item_count`, neither of which was ever created.)
+        #
+        # ai_model/effort are deliberately NOT their DDL defaults ('opus'/'high'):
+        # posting the default would make the read-back below pass even if the
+        # field never reached the INSERT at all.
         create_resp = invoke('POST', '/darwin_dev/swarm_starts', body={
             'arguments': 'swarm 1 2 3',
-            'category_filter': 'swarm',
             'autonomy_filter': 'implemented',
             'auto_start': '0',
-            'item_count': '3',
             'session_count': '3',
+            'ai_model': 'sonnet',
+            'effort': 'xhigh',
             'creator_fk': creator_fk,
         })
         assert create_resp['statusCode'] == 200
@@ -48,6 +56,9 @@ class TestSwarmStartsCRUD:
         assert body[0]['session_count'] == 5
         assert body[0]['auto_start'] == 1
         assert body[0]['arguments'] == 'swarm 1 2 3'
+        assert body[0]['autonomy_filter'] == 'implemented'
+        assert body[0]['ai_model'] == 'sonnet'
+        assert body[0]['effort'] == 'xhigh'
 
         # Step 4: DELETE
         delete_resp = invoke('DELETE', '/darwin_dev/swarm_starts', body={'id': swarm_start_id})


### PR DESCRIPTION
## Summary
- wip(Lambda-Rest): 2026-07-26T00:57:25Z
- chore: init swarm session feature/3061-two-stale-backend-test-files-fail-1

## Files changed
```
 tests/test_instructions.py | 17 +++++++++++++----
 tests/test_swarm_starts.py | 17 ++++++++++++++---
 2 files changed, 27 insertions(+), 7 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Related PRs: BillWilliams79/DarwinAI-Config#636, BillWilliams79/AWS-Lambda-REST-API#54 (req #3061)