### PR TITLE
Map pymysql IntegrityError to HTTP 409 in Lambda-Rest

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ AWS Lambda function serving a REST API backed by MySQL (RDS) via API Gateway pro
 ## Architecture
 
 - `handler.py` — Lambda entry point (`lambda_handler`). Parses the URL path into database + table, routes by httpMethod.
-- `rest_api_utils.py` — `compose_rest_response(status_code, body, http_message)` builds the API Gateway Lambda proxy response dict. Always calls `json.dumps(body)` on the body before inserting it. On error status codes (not 200/201/204), replaces body with http_message.
+- `rest_api_utils.py` — `compose_rest_response(status_code, body, http_message)` builds the API Gateway Lambda proxy response dict. Always calls `json.dumps(body)` on the body before inserting it. On error status codes (not 200/201/204), replaces body with http_message. Also owns the 409 CONFLICT mapping (see below).
 - `classifier.py` — `varDump(value, description, dump_type)` for debug printing, `pretty_print_sql()` collapses whitespace for readable SQL logs.
 - `pymysql/` — Vendored MySQL driver (do not modify)
 
@@ -23,6 +23,46 @@ AWS Lambda function serving a REST API backed by MySQL (RDS) via API Gateway pro
 - Connection is established at module load time (Lambda cold start), stored in `connection` dict keyed by database name
 - Two databases configured: `darwin` (production), `darwin_dev` (testing)
 - Uses pymysql with credentials from environment variables
+
+## Error Status Contract
+
+Every failure used to be a 500 whose body was the raw pymysql string, so a client
+could not tell "you picked a taken name" from "the database is broken" without
+regexing prose. **Req #3059** carved out the conflicts:
+
+| MySQL errno | Meaning | Status |
+|---|---|---|
+| 1062 | Duplicate entry — UNIQUE / PRIMARY KEY collision | **409** |
+| 1451 | Cannot delete or update a parent row (FK RESTRICT) | **409** |
+| 1452 | Cannot add or update a child row (FK target missing) | **409** |
+| everything else | 1054 unknown column, 1364 no default, 2013 lost connection, … | 500 |
+
+The line is the promise a 409 makes: *retrying with different data can succeed*.
+Do not widen `INTEGRITY_ERRNOS` without checking a new errno keeps it — a client
+that retries on a 409 it can never satisfy loops forever.
+
+409 body (single-encoded JSON **object**, unlike every other error status, which
+sends a bare JSON string):
+
+```json
+{"error": "CONFLICT", "errno": 1062,
+ "constraint": "uq_instructions_name", "table": "instructions",
+ "message": "HTTP PUT SQL FAILED: 1062 Duplicate entry 'x' for key 'instructions.uq_instructions_name'"}
+```
+
+- `constraint` is **unqualified** — MySQL 8 reports the key as `table.index`, 5.7
+  as `index`; the qualifier is stripped so it matches the name the DDL declares.
+  Every table has a `PRIMARY`, so it only identifies anything paired with `table`.
+- `table` comes from the handler, not from parsing the driver message.
+- `message` is byte-identical to what the 500 path used to send. That is a
+  compatibility promise: `darwin-mcp/darwin_rest/client.py` falls back to
+  substring-matching it, and log greps written against the 500 era still work.
+
+Applies to `rest_post.py` (single + bulk), `rest_put.py`, `rest_delete.py`
+(single + bulk). **NOT** to rest_post's post-insert read-back failure — that 500
+means the INSERT already committed, and `darwin-mcp`'s `post_junction` reads it
+that way. Helpers + boundary are unit-tested in `tests/test_unit_conflict.py`
+(no DB needed).
 
 ## CRUD Modules
 

--- a/rest_api_utils.py
+++ b/rest_api_utils.py
@@ -1,4 +1,5 @@
 import json
+import re
 from classifier import varDump
 
 #
@@ -22,10 +23,14 @@ def compose_rest_response(status_code, body='', http_message=''):
         }
     }
 
+    # On an error status the body IS http_message — whatever the caller passed as
+    # `body` is discarded. http_message is usually a string; the 409 path
+    # (req #3059) passes a dict, which json.dumps renders as a JSON OBJECT so the
+    # client reads errno and constraint instead of parsing prose.
     if status_code not in (200, 201, 204):
         print(f"Error message inserted into body.  {body} : {http_message}")
         body = http_message
- 
+
     #
     # json encode body, insert into response
     #
@@ -37,3 +42,105 @@ def compose_rest_response(status_code, body='', http_message=''):
     #varDump(lambda_rest_api_response, 'Lambda proxy response')
 
     return lambda_rest_api_response
+
+
+# ---------------------------------------------------------------------------
+# Integrity violations -> HTTP 409 CONFLICT (req #3059)
+# ---------------------------------------------------------------------------
+#
+# Before this, EVERY pymysql failure was a 500 carrying the raw driver message,
+# so a client could not tell "you picked a taken name" from "the database is
+# broken" without regex-matching prose. Three errnos mean the request conflicts
+# with data that already exists, and only those three get the 409:
+#
+#   1062  Duplicate entry ... for key ...       UNIQUE / PRIMARY KEY collision
+#   1451  Cannot delete or update a parent row  FK RESTRICT protecting children
+#   1452  Cannot add or update a child row      FK pointing at a row that is gone
+#
+# The line is deliberate, not a shortlist to grow casually: a 409 tells the
+# caller that retrying with different data can succeed. A missing column (1054),
+# a NOT NULL with no default (1364), a lost connection (2013) — none of those
+# keep that promise, so they stay 500s.
+
+INTEGRITY_ERRNOS = frozenset({1062, 1451, 1452})
+
+# `... for key 'instructions.uq_instructions_name'` — MySQL 8 qualifies the key
+# name with its table, 5.7 does not. Anchored at end-of-message and quote-free in
+# the group so a duplicated VALUE that itself contains "for key '...'" cannot be
+# mistaken for the key.
+_DUP_KEY_RE = re.compile(r"for key '([^']+)'\s*$")
+
+# ``... (`darwin_dev`.`areas`, CONSTRAINT `areas_ibfk_1` FOREIGN KEY ...)``
+_FK_CONSTRAINT_RE = re.compile(r"CONSTRAINT `([^`]+)`")
+
+
+def error_detail(exc):
+    """(errno, message) from a pymysql.Error, tolerant of a short args tuple.
+
+    All eleven error-formatting sites in the CRUD modules — rest_post (5),
+    rest_get_table (2), rest_put, rest_delete (2), rest_get_database — used to
+    read `f"...: {e.args[0]} {e.args[1]}"` directly. pymysql raises ONE-arg
+    errors from its own plumbing (`ProgrammingError("Cursor closed")`,
+    `Error("Already closed")`), so that raised IndexError from INSIDE the
+    `except pymysql.Error` block; `lambda_handler`'s blanket `except Exception`
+    then swallowed it into a 503 SERVICE_UNAVAILABLE naming nothing. On a GET
+    that also cost a round trip — darwin-mcp retries idempotent GETs once on 503.
+
+    Going through here keeps the 2-arg message byte-identical (verified per-site)
+    and turns the short-args case into a real 500 that names the failure.
+    `tests/test_unit_error_detail_wiring.py` holds the sites to this; the pure
+    function is covered in `tests/test_unit_conflict.py`.
+    """
+    errno = exc.args[0] if exc.args else None
+    message = exc.args[1] if len(exc.args) > 1 else ''
+    return errno, message
+
+
+def integrity_errno(exc):
+    """The MySQL errno of `exc` when it is an integrity violation, else None.
+
+    Total over every shape pymysql raises, including no args at all — this is
+    called from inside an `except` block, where anything it raised would escape
+    as a 503 that names nothing.
+    """
+    errno, _ = error_detail(exc)
+    try:
+        return errno if errno in INTEGRITY_ERRNOS else None
+    except TypeError:
+        return None          # unhashable args[0] — not an errno by any reading
+
+
+def constraint_name(errno, message):
+    """The index / FK name the violation names, unqualified. None when absent.
+
+    MySQL 8 reports a duplicate key as `table.index`; the schema declares plain
+    `index`. Stripping the qualifier lets a consumer compare against the name it
+    can actually read in the DDL — and nothing is lost, because the response
+    carries `table` separately, sourced from the handler rather than the message.
+    """
+    match = (_DUP_KEY_RE if errno == 1062 else _FK_CONSTRAINT_RE).search(message or '')
+    return match.group(1).rsplit('.', 1)[-1] if match else None
+
+
+def compose_conflict_response(table, exc, error_message):
+    """409 CONFLICT for a MySQL integrity violation, with a structured body.
+
+    Body shape:
+
+        {"error": "CONFLICT", "errno": 1062,
+         "constraint": "uq_instructions_name", "table": "instructions",
+         "message": "HTTP PUT SQL FAILED: 1062 Duplicate entry 'x' for key ..."}
+
+    `error_message` is the exact string the 500 path used to put on the wire and
+    is echoed verbatim under `message`. That is a compatibility promise, not
+    padding: darwin-mcp's client._translate and any log grep written against the
+    old contract keep working while they move over to `errno`.
+    """
+    errno, detail = error_detail(exc)
+    return compose_rest_response(409, '', {
+        'error': 'CONFLICT',
+        'errno': errno,
+        'constraint': constraint_name(errno, detail),
+        'table': table,
+        'message': error_message,
+    })

--- a/rest_delete.py
+++ b/rest_delete.py
@@ -1,6 +1,7 @@
 import pymysql
 import json
-from rest_api_utils import compose_rest_response
+from rest_api_utils import (compose_rest_response, compose_conflict_response,
+                            error_detail, integrity_errno)
 from classifier import varDump, pretty_print_sql
 from auth_utils import CREATOR_FK_TABLES, PROFILE_TABLE
 
@@ -46,8 +47,11 @@ def rest_delete(delete_method, conn, database, table, body, authenticated_user=N
             return compose_rest_response(200, '', 'OK')
 
     except pymysql.Error as e:
-        errorMsg = f"HTTP {delete_method} SQL FAILED: {e.args[0]} {e.args[1]}"
+        errno, detail = error_detail(e)
+        errorMsg = f"HTTP {delete_method} SQL FAILED: {errno} {detail}"
         print(errorMsg)
+        if integrity_errno(e):
+            return compose_conflict_response(table, e, errorMsg)
         return compose_rest_response(500, '', errorMsg)
 
 
@@ -100,6 +104,9 @@ def _rest_delete_bulk(delete_method, conn, table, body_list, authenticated_user)
 
     except pymysql.Error as e:
         conn.rollback()
-        errorMsg = f"HTTP {delete_method} bulk SQL FAILED: {e.args[0]} {e.args[1]}"
+        errno, detail = error_detail(e)
+        errorMsg = f"HTTP {delete_method} bulk SQL FAILED: {errno} {detail}"
         print(errorMsg)
+        if integrity_errno(e):
+            return compose_conflict_response(table, e, errorMsg)
         return compose_rest_response(500, '', errorMsg)

--- a/rest_get_database.py
+++ b/rest_get_database.py
@@ -1,6 +1,6 @@
 import json
 import pymysql
-from rest_api_utils import compose_rest_response
+from rest_api_utils import compose_rest_response, error_detail
 from classifier import varDump
 
 def rest_get_database(get_method, conn, database):
@@ -25,6 +25,7 @@ def rest_get_database(get_method, conn, database):
             return compose_rest_response(404,  '', 'NOT FOUND')
 
     except pymysql.Error as e:
-        errorMsg = f"HTTP {get_method}: show tables command failed: {e.args[0]} {e.args[1]}"
+        errno, detail = error_detail(e)
+        errorMsg = f"HTTP {get_method}: show tables command failed: {errno} {detail}"
         print(errorMsg)
         return compose_rest_response(500, '', errorMsg)

--- a/rest_get_table.py
+++ b/rest_get_table.py
@@ -1,6 +1,6 @@
 import pymysql
 import json
-from rest_api_utils import compose_rest_response
+from rest_api_utils import compose_rest_response, error_detail
 from classifier import varDump, pretty_print_sql
 from auth_utils import CREATOR_FK_TABLES, PROFILE_TABLE
 
@@ -23,7 +23,8 @@ def rest_get_table(get_method, conn, database, table, event, authenticated_user=
             sql_columns.append(row[0])
 
     except pymysql.Error as e:
-        errorMsg = f"HTTP {get_method} helper SQL command failed: {e.args[0]} {e.args[1]}"
+        errno, detail = error_detail(e)
+        errorMsg = f"HTTP {get_method} helper SQL command failed: {errno} {detail}"
         print(errorMsg)
         return compose_rest_response(500, '', errorMsg)
 
@@ -199,6 +200,7 @@ def rest_get_table(get_method, conn, database, table, event, authenticated_user=
             return compose_rest_response(404, '', 'NOT FOUND')
 
     except pymysql.Error as e:
-        errorMsg = f"HTTP {get_method} actual SQL select statement failed: {e.args[0]} {e.args[1]}"
+        errno, detail = error_detail(e)
+        errorMsg = f"HTTP {get_method} actual SQL select statement failed: {errno} {detail}"
         print(errorMsg)
         return compose_rest_response(500, '', errorMsg)

--- a/rest_post.py
+++ b/rest_post.py
@@ -1,6 +1,7 @@
 import pymysql
 import json
-from rest_api_utils import compose_rest_response
+from rest_api_utils import (compose_rest_response, compose_conflict_response,
+                            error_detail, integrity_errno)
 from classifier import varDump, pretty_print_sql
 from auth_utils import CREATOR_FK_TABLES, PROFILE_TABLE
 
@@ -47,8 +48,11 @@ def rest_post(post_method, conn, database, table, body, authenticated_user=None)
             return compose_rest_response(500, '', "NO DATA SAVED")
 
     except pymysql.Error as e:
-        errorMsg = f"HTTP {post_method} failed: {e.args[0]} {e.args[1]}"
+        errno, detail = error_detail(e)
+        errorMsg = f"HTTP {post_method} failed: {errno} {detail}"
         print(errorMsg)
+        if integrity_errno(e):
+            return compose_conflict_response(table, e, errorMsg)
         return compose_rest_response(500, '', errorMsg)
 
     try:
@@ -64,7 +68,8 @@ def rest_post(post_method, conn, database, table, body, authenticated_user=None)
                 return compose_rest_response(201, '', 'CREATED')
 
     except pymysql.Error as e:
-        print(f"HTTP {post_method} FAILED to read last_insert_id: {e.args[0]} {e.args[1]}")
+        errno, detail = error_detail(e)
+        print(f"HTTP {post_method} FAILED to read last_insert_id: {errno} {detail}")
         return compose_rest_response(201, '', 'CREATED')
 
     try:
@@ -80,7 +85,8 @@ def rest_post(post_method, conn, database, table, body, authenticated_user=None)
             sql_columns.append(row[0])
         
     except pymysql.Error as e:
-        errorMsg = f"HTTP {post_method} helper DESC SQL command failed: {e.args[0]} {e.args[1]}"
+        errno, detail = error_detail(e)
+        errorMsg = f"HTTP {post_method} helper DESC SQL command failed: {errno} {detail}"
         print(errorMsg)
         return compose_rest_response(201, '', 'CREATED')
 
@@ -111,7 +117,12 @@ def rest_post(post_method, conn, database, table, body, authenticated_user=None)
             return compose_rest_response(201, '', 'CREATED')
 
     except pymysql.Error as e:
-        errorMsg = f"HTTP {post_method} helper SELECT after WRITE SQL command failed: {e.args[0]} {e.args[1]}"
+        # Stays a 500 even for an integrity errno, which cannot reach here anyway:
+        # the INSERT already committed under autocommit, so this is a failed READ,
+        # not a rejected write. darwin-mcp's post_junction depends on that — it
+        # reads the 1054 "Unknown column 'id'" 500 as "the row IS there".
+        errno, detail = error_detail(e)
+        errorMsg = f"HTTP {post_method} helper SELECT after WRITE SQL command failed: {errno} {detail}"
         print(errorMsg)
         return compose_rest_response(500, '', errorMsg)
 
@@ -163,6 +174,9 @@ def _rest_post_bulk(post_method, conn, table, body_list, authenticated_user):
 
     except pymysql.Error as e:
         conn.rollback()
-        errorMsg = f"HTTP {post_method} bulk failed: {e.args[0]} {e.args[1]}"
+        errno, detail = error_detail(e)
+        errorMsg = f"HTTP {post_method} bulk failed: {errno} {detail}"
         print(errorMsg)
+        if integrity_errno(e):
+            return compose_conflict_response(table, e, errorMsg)
         return compose_rest_response(500, '', errorMsg)

--- a/rest_put.py
+++ b/rest_put.py
@@ -1,6 +1,7 @@
 import pymysql
 import json
-from rest_api_utils import compose_rest_response
+from rest_api_utils import (compose_rest_response, compose_conflict_response,
+                            error_detail, integrity_errno)
 from classifier import varDump, pretty_print_sql
 from auth_utils import CREATOR_FK_TABLES, PROFILE_TABLE
 
@@ -152,6 +153,9 @@ def rest_put(put_method, conn, database, table, body_list, authenticated_user=No
             return compose_rest_response(204, 'NO DATA CHANGED', 'NO DATA CHANGED')
 
     except pymysql.Error as e:
-        errorMsg = f"HTTP {put_method} SQL FAILED: {e.args[0]} {e.args[1]}"
+        errno, detail = error_detail(e)
+        errorMsg = f"HTTP {put_method} SQL FAILED: {errno} {detail}"
         print(errorMsg)
+        if integrity_errno(e):
+            return compose_conflict_response(table, e, errorMsg)
         return compose_rest_response(500, '', errorMsg)

--- a/tests/test_agent_instructions.py
+++ b/tests/test_agent_instructions.py
@@ -12,6 +12,10 @@ locked here because both are invisible until something depends on them:
    regression: `test_swarm_starts.py` documents the same read-back assumption,
    and the fix belongs in `rest_post.py`, not here.
 
+   This 500 stayed a 500 through req #3059's 409 mapping, deliberately: 1054 is
+   not an integrity errno, and darwin-mcp's `post_junction` reads exactly this
+   response as "the row IS committed, go read it back".
+
 2. **An ARRAY body works.** `_rest_post_bulk` does no read-back, so it returns
    201 `{"inserted": N}`. That is the ONLY sound insert path for this table and
    the one `Darwin/src/Agents/actions/instructionsApi.js` uses for every link,
@@ -29,6 +33,7 @@ from conftest import extract_id
 
 
 def _err(response):
+    """A dict for 409 CONFLICT (req #3059), a bare string for any other error."""
     return json.loads(response['body'])
 
 
@@ -123,7 +128,14 @@ class TestAgentInstructionsInsert:
         rows = _links(db_connection, agent)
         assert [r['instruction_fk'] for r in rows] == [instruction]
 
-    def test_duplicate_link_is_500_with_1062(self, invoke, registry):
+    def test_duplicate_link_is_409_conflict(self, invoke, registry):
+        """req #3059: the bulk INSERT path reports a composite-PK collision.
+
+        `constraint` is 'PRIMARY' — which every table has — so it only identifies
+        anything paired with `table`. That is exactly how the UI reads it, and
+        why `table` is sourced from the handler rather than parsed out of the
+        driver's `'agent_instructions.PRIMARY'`.
+        """
         agent = registry['agent']('dupe')
         instruction = registry['instruction']('dupe-a')
         body = [{'agent_fk': agent, 'instruction_fk': instruction, 'sort_order': 1}]
@@ -131,18 +143,21 @@ class TestAgentInstructionsInsert:
         assert invoke('POST', '/darwin_dev/agent_instructions',
                       body=body)['statusCode'] == 201
         resp = invoke('POST', '/darwin_dev/agent_instructions', body=body)
-        assert resp['statusCode'] == 500
-        message = _err(resp)
-        assert '1062' in message
-        assert 'agent_instructions.PRIMARY' in message
+        assert resp['statusCode'] == 409
+        payload = _err(resp)
+        assert payload['errno'] == 1062
+        assert payload['constraint'] == 'PRIMARY'
+        assert payload['table'] == 'agent_instructions'
 
-    def test_bad_foreign_key_is_500_with_1452(self, invoke, registry):
+    def test_bad_foreign_key_is_409_conflict(self, invoke, registry):
         instruction = registry['instruction']('badfk-a')
         resp = invoke('POST', '/darwin_dev/agent_instructions', body=[
             {'agent_fk': 999999999, 'instruction_fk': instruction, 'sort_order': 1},
         ])
-        assert resp['statusCode'] == 500
-        assert '1452' in _err(resp)
+        assert resp['statusCode'] == 409
+        payload = _err(resp)
+        assert payload['errno'] == 1452
+        assert payload['table'] == 'agent_instructions'
 
 
 class TestAgentInstructionsDelete:

--- a/tests/test_error_paths.py
+++ b/tests/test_error_paths.py
@@ -46,24 +46,30 @@ class TestPostErrorPaths:
             pass  # Exception is also acceptable
 
     # -----------------------------------------------------------------------
-    # POST-03: FK violation returns 500
+    # POST-03: FK violation returns 409
     # -----------------------------------------------------------------------
 
-    def test_post_fk_violation_returns_500(self, invoke):
-        """POST-03: POST with invalid FK (domain_fk='999999') returns 500.
+    def test_post_fk_violation_returns_409(self, invoke):
+        """POST-03: POST with invalid FK (domain_fk='999999') returns 409.
 
         creator_fk is overridden from JWT (valid), but domain_fk is invalid.
-        May raise an exception; accept both 500 status or exception.
+
+        req #3059 moved this off 500: pointing at a domain that does not exist is
+        a conflict with the current state of the data, and a caller CAN fix it by
+        sending a real domain_fk. The bare `except Exception: pass` the sibling
+        tests use is gone — it would have swallowed a wrong status silently, and
+        this assertion is the whole point of the test.
         """
-        try:
-            response = invoke('POST', '/darwin_dev/areas', body={
-                'area_name': 'Bad FK',
-                'domain_fk': '999999',
-                'closed': '0',
-            })
-            assert response['statusCode'] == 500
-        except Exception:
-            pass  # Exception is also acceptable
+        response = invoke('POST', '/darwin_dev/areas', body={
+            'area_name': 'Bad FK',
+            'domain_fk': '999999',
+            'closed': '0',
+        })
+        assert response['statusCode'] == 409
+        body = json.loads(response['body'])
+        assert body['error'] == 'CONFLICT'
+        assert body['errno'] == 1452
+        assert body['table'] == 'areas'
 
     # -----------------------------------------------------------------------
     # POST-04: Response single-encoded verification

--- a/tests/test_instructions.py
+++ b/tests/test_instructions.py
@@ -4,11 +4,11 @@ The Darwin UI at /agents/instructions writes this table directly, so these tests
 lock the behaviours that UI depends on. Two are contracts about FAILURE, and they
 matter as much as the happy path:
 
-- A duplicate `name` surfaces as HTTP **500** carrying the raw pymysql message,
-  not a 409. The UI parses `1062` + `uq_instructions_name` out of that string to
-  tell "you picked a taken name" from "the database is broken". If someone later
-  maps IntegrityError to a real status code, these tests fail and force the UI's
-  error parser to be updated in the same change.
+- A duplicate `name` surfaces as HTTP **409** with a structured CONFLICT body
+  (req #3059 — it used to be a 500 carrying the raw pymysql string, which the UI
+  had to regex). `agentRegistryUtils.restErrorMessage` reads `errno` and
+  `constraint` off that body, so a change to either field here breaks the UI's
+  "that name is taken" message and must be made in the same commit.
 - `instructions` is in CREATOR_FK_TABLES, so a client-supplied `creator_fk` must
   be OVERWRITTEN with the authenticated Cognito sub, never trusted.
 """
@@ -20,7 +20,10 @@ from conftest import extract_id
 
 
 def _err(response):
-    """The error string Lambda-Rest puts on the wire (JSON-encoded)."""
+    """The error payload Lambda-Rest puts on the wire (JSON-encoded).
+
+    A dict for 409 CONFLICT, a bare string for every other error status.
+    """
     return json.loads(response['body'])
 
 
@@ -113,28 +116,49 @@ class TestInstructionsCRUD:
 class TestInstructionsUniqueName:
     """The exact wire contract the UI's error parser reads."""
 
-    def test_duplicate_name_post_is_500_with_1062(self, invoke, creator_fk, instruction):
+    def test_duplicate_name_post_is_409_conflict(self, invoke, creator_fk, instruction):
         name = f'pytest-{creator_fk}-dupe'
         instruction(name)
         resp = invoke('POST', '/darwin_dev/instructions', body={
             'name': name, 'content': 'second row', 'creator_fk': creator_fk,
         })
-        assert resp['statusCode'] == 500
-        message = _err(resp)
-        assert '1062' in message
-        assert 'uq_instructions_name' in message
+        assert resp['statusCode'] == 409
+        body = _err(resp)
+        assert body['error'] == 'CONFLICT'
+        assert body['errno'] == 1062
+        assert body['constraint'] == 'uq_instructions_name'
+        assert body['table'] == 'instructions'
+        # The raw driver string is still carried, unchanged from the 500 era.
+        assert '1062' in body['message']
 
-    def test_rename_onto_existing_name_is_500_with_1062(self, invoke, creator_fk, instruction):
+    def test_rename_onto_existing_name_is_409_conflict(self, invoke, creator_fk, instruction):
         taken = f'pytest-{creator_fk}-taken'
         instruction(taken)
         victim_id = instruction(f'pytest-{creator_fk}-victim')
 
         resp = invoke('PUT', '/darwin_dev/instructions',
                       body=[{'id': victim_id, 'name': taken}])
-        assert resp['statusCode'] == 500
-        message = _err(resp)
-        assert '1062' in message
-        assert 'uq_instructions_name' in message
+        assert resp['statusCode'] == 409
+        body = _err(resp)
+        assert body['errno'] == 1062
+        assert body['constraint'] == 'uq_instructions_name'
+        assert body['table'] == 'instructions'
+
+    def test_the_constraint_name_is_unqualified(self, invoke, creator_fk, instruction):
+        """MySQL 8 reports the key as `instructions.uq_instructions_name`.
+
+        The response strips the table qualifier so a consumer can compare against
+        the name the DDL declares — `table` carries what the strip removed. The
+        UI's equality check depends on this; a qualified value would silently
+        stop matching and every duplicate would render the generic fallback.
+        """
+        name = f'pytest-{creator_fk}-unqualified'
+        instruction(name)
+        body = _err(invoke('POST', '/darwin_dev/instructions', body={
+            'name': name, 'content': 'x', 'creator_fk': creator_fk,
+        }))
+        assert body['constraint'] == 'uq_instructions_name'
+        assert '.' not in body['constraint']
 
     def test_unique_key_does_not_exclude_closed_rows(self, invoke, creator_fk, instruction):
         """A CLOSED row still owns its name.
@@ -150,8 +174,22 @@ class TestInstructionsUniqueName:
         resp = invoke('POST', '/darwin_dev/instructions', body={
             'name': name, 'content': 'reusing a retired name', 'creator_fk': creator_fk,
         })
+        assert resp['statusCode'] == 409
+        assert _err(resp)['constraint'] == 'uq_instructions_name'
+
+    def test_a_non_integrity_failure_is_still_a_500(self, invoke, creator_fk):
+        """The boundary, asserted against the live handler.
+
+        A 409 promises the caller that different data can succeed. An unknown
+        column (1054) never can, so it must NOT be swept into the conflict path —
+        a client that retries on it would loop forever.
+        """
+        resp = invoke('POST', '/darwin_dev/instructions', body={
+            'name': f'pytest-{creator_fk}-badcol', 'content': 'x',
+            'no_such_column': 'boom', 'creator_fk': creator_fk,
+        })
         assert resp['statusCode'] == 500
-        assert 'uq_instructions_name' in _err(resp)
+        assert isinstance(_err(resp), str)
 
 
 class TestInstructionsCreatorIsolation:

--- a/tests/test_unit_conflict.py
+++ b/tests/test_unit_conflict.py
@@ -1,0 +1,177 @@
+"""Unit tests for the 409 CONFLICT mapping (req #3059).
+
+Pure-function tests over `rest_api_utils` — no database, no `exports.sh`. The
+integration counterparts that prove the real Lambda emits these live in
+`test_instructions.py` (1062 on a UNIQUE name) and `test_agent_instructions.py`
+(1062 on a composite PK, 1452 on a bad FK).
+
+The two things worth locking here are the boundary and the parsing:
+
+- WHICH errnos become a 409. A 409 tells the caller "retry with different data
+  and this can succeed". 1054 (unknown column) and 1364 (no default) do not keep
+  that promise and must stay 500s, or a client will retry forever.
+- The `constraint` extraction, because both regexes read attacker-influenced
+  text: the duplicated VALUE is echoed inside the 1062 message.
+"""
+import json
+
+import pymysql
+import pytest
+
+from rest_api_utils import (INTEGRITY_ERRNOS, compose_conflict_response,
+                            constraint_name, error_detail, integrity_errno)
+
+
+DUP_INSTRUCTION = ("Duplicate entry 'binding-rules' for key "
+                   "'instructions.uq_instructions_name'")
+DUP_JUNCTION = "Duplicate entry '10-6' for key 'agent_instructions.PRIMARY'"
+FK_CHILD = ("Cannot add or update a child row: a foreign key constraint fails "
+            "(`darwin_dev`.`areas`, CONSTRAINT `areas_ibfk_1` FOREIGN KEY "
+            "(`domain_fk`) REFERENCES `domains` (`id`))")
+FK_PARENT = ("Cannot delete or update a parent row: a foreign key constraint "
+             "fails (`darwin_dev`.`requirements`, CONSTRAINT "
+             "`fk_requirements_category` FOREIGN KEY (`category_fk`) "
+             "REFERENCES `categories` (`id`))")
+
+
+def err(errno, message):
+    return pymysql.Error(errno, message)
+
+
+class TestIntegrityErrno:
+
+    @pytest.mark.parametrize('errno', [1062, 1451, 1452])
+    def test_the_three_conflict_errnos_are_recognised(self, errno):
+        assert integrity_errno(err(errno, 'whatever')) == errno
+
+    @pytest.mark.parametrize('errno, why', [
+        (1054, 'unknown column — the request is malformed, not conflicting'),
+        (1364, "field has no default — retrying identical data won't help"),
+        (1048, 'column cannot be null — same'),
+        (2013, 'lost connection — the database really is broken'),
+    ])
+    def test_everything_else_stays_a_500(self, errno, why):
+        assert integrity_errno(err(errno, 'whatever')) is None, why
+
+    def test_the_errno_set_is_exactly_three(self):
+        # Guards against a casual addition: widening this set changes the
+        # promise 409 makes to every client of every table.
+        assert INTEGRITY_ERRNOS == frozenset({1062, 1451, 1452})
+
+    def test_an_exception_with_no_args_does_not_raise(self):
+        # pymysql raises arg-less errors from the connection layer. This is
+        # called from inside an `except` block, so a crash here would escape and
+        # be swallowed by handler.py's blanket catch as a 503 naming nothing.
+        assert integrity_errno(pymysql.Error()) is None
+
+    def test_an_unhashable_args0_does_not_raise(self):
+        # `[] in frozenset(...)` raises TypeError in CPython. pymysql never does
+        # this, but the cost of being total here is one except clause.
+        assert integrity_errno(pymysql.Error([], 'weird')) is None
+
+
+class TestErrorDetail:
+    """The accessor the CRUD modules build their error line from.
+
+    pymysql raises ONE-arg errors from its own plumbing —
+    `ProgrammingError("Cursor closed")`, `Error("Already closed")`. Every module
+    used to format `f"{e.args[0]} {e.args[1]}"`, which raised IndexError from
+    inside the `except pymysql.Error` block; handler.py's blanket catch turned
+    that into a 503 SERVICE_UNAVAILABLE that named nothing.
+    """
+
+    def test_the_normal_two_arg_shape(self):
+        assert error_detail(err(1062, DUP_INSTRUCTION)) == (1062, DUP_INSTRUCTION)
+
+    def test_a_one_arg_error_yields_an_empty_message_not_an_indexerror(self):
+        assert error_detail(pymysql.ProgrammingError('Cursor closed')) \
+            == ('Cursor closed', '')
+
+    def test_a_zero_arg_error_yields_nones(self):
+        assert error_detail(pymysql.Error()) == (None, '')
+
+    def test_extra_args_are_ignored(self):
+        assert error_detail(pymysql.Error(1062, 'msg', 'extra')) == (1062, 'msg')
+
+
+class TestConstraintName:
+
+    def test_mysql8_duplicate_key_is_unqualified(self):
+        assert constraint_name(1062, DUP_INSTRUCTION) == 'uq_instructions_name'
+
+    def test_mysql57_duplicate_key_has_no_qualifier_to_strip(self):
+        assert constraint_name(
+            1062, "Duplicate entry 'x' for key 'uq_instructions_name'") \
+            == 'uq_instructions_name'
+
+    def test_a_composite_primary_key_reports_PRIMARY(self):
+        # Unqualified, so it is only meaningful next to the response's `table`.
+        assert constraint_name(1062, DUP_JUNCTION) == 'PRIMARY'
+
+    def test_a_value_containing_the_key_phrase_does_not_fool_the_regex(self):
+        # The duplicated VALUE is echoed into the message, so it is caller-
+        # controlled text. Only the trailing key is the key.
+        message = ("Duplicate entry 'evil' for key 'fake' for key "
+                   "'instructions.uq_instructions_name'")
+        assert constraint_name(1062, message) == 'uq_instructions_name'
+
+    def test_child_row_fk_reports_the_constraint(self):
+        assert constraint_name(1452, FK_CHILD) == 'areas_ibfk_1'
+
+    def test_parent_row_fk_reports_the_constraint(self):
+        assert constraint_name(1451, FK_PARENT) == 'fk_requirements_category'
+
+    def test_an_unparseable_message_yields_none_rather_than_guessing(self):
+        assert constraint_name(1451, 'a foreign key constraint fails') is None
+        assert constraint_name(1062, '') is None
+        assert constraint_name(1062, None) is None
+
+
+class TestComposeConflictResponse:
+
+    def test_the_wire_shape(self):
+        wire = "HTTP PUT SQL FAILED: 1062 " + DUP_INSTRUCTION
+        resp = compose_conflict_response('instructions',
+                                         err(1062, DUP_INSTRUCTION), wire)
+
+        assert resp['statusCode'] == 409
+        assert json.loads(resp['body']) == {
+            'error': 'CONFLICT',
+            'errno': 1062,
+            'constraint': 'uq_instructions_name',
+            'table': 'instructions',
+            'message': wire,
+        }
+
+    def test_the_message_is_echoed_verbatim(self):
+        """The compatibility promise the rollout depends on.
+
+        darwin-mcp's client._translate falls back to substring-matching this
+        string when a response carries no `errno`, and log greps written against
+        the 500 era read it too.
+        """
+        wire = "HTTP POST bulk failed: 1062 " + DUP_JUNCTION
+        body = json.loads(compose_conflict_response(
+            'agent_instructions', err(1062, DUP_JUNCTION), wire)['body'])
+        assert body['message'] == wire
+        assert 'Duplicate entry' in body['message']
+
+    def test_table_comes_from_the_handler_not_the_message(self):
+        # `constraint` is 'PRIMARY' for every table, so `table` is what makes the
+        # pair identifying — and it must not be parsed out of driver prose.
+        body = json.loads(compose_conflict_response(
+            'agent_instructions', err(1062, DUP_JUNCTION), 'x')['body'])
+        assert (body['table'], body['constraint']) == ('agent_instructions', 'PRIMARY')
+
+    def test_body_is_single_encoded_json(self):
+        # compose_rest_response json.dumps() once. A dict that arrived
+        # pre-stringified would land on the wire double-encoded and every client
+        # would read a string where it expects an object.
+        resp = compose_conflict_response('areas', err(1452, FK_CHILD), 'x')
+        assert isinstance(json.loads(resp['body']), dict)
+
+    def test_an_exception_missing_its_message_arg_still_composes(self):
+        body = json.loads(compose_conflict_response(
+            'areas', pymysql.Error(1062), 'HTTP POST failed: 1062')['body'])
+        assert body['errno'] == 1062
+        assert body['constraint'] is None

--- a/tests/test_unit_error_detail_wiring.py
+++ b/tests/test_unit_error_detail_wiring.py
@@ -1,0 +1,117 @@
+"""Every CRUD entry point survives a pymysql error carrying only ONE arg.
+
+This is the regression guard for the defect req #3059's code review found, and it
+is deliberately separate from `test_unit_conflict.py`: that file tests
+`error_detail` as a pure function, which proves the helper is safe but proves
+NOTHING about whether the modules actually call it. Someone could reintroduce
+`f"{e.args[0]} {e.args[1]}"` at any of the eleven sites and every other unit test
+would stay green, because the tests that drive these functions for real need a
+live database and are all skipped without `exports.sh`.
+
+The bug: pymysql raises one-arg errors from its own plumbing —
+`ProgrammingError("Cursor closed")` (cursors.py), `Error("Already closed")`
+(connections.py). Reading `e.args[1]` inside `except pymysql.Error` raised
+IndexError, which escaped the handler's per-module error path and was swallowed
+by `lambda_handler`'s blanket `except Exception` as a 503 SERVICE_UNAVAILABLE
+that named nothing. On a GET that 503 is worse than cosmetic: darwin-mcp retries
+idempotent GETs once on 503, so it silently double-fetched before surfacing
+DB_UNAVAILABLE.
+
+No database required — the connection is a stub whose cursor() raises.
+"""
+import json
+
+import pymysql
+import pytest
+
+from rest_delete import rest_delete
+from rest_get_database import rest_get_database
+from rest_get_table import rest_get_table
+from rest_post import rest_post
+from rest_put import rest_put
+
+
+class OneArgErrorConn:
+    """A connection whose every cursor() raises pymysql's one-arg error.
+
+    Mirrors pymysql's real behaviour: `Cursor.execute` on a closed cursor raises
+    `ProgrammingError('Cursor closed')` — args of length 1, no errno.
+    """
+
+    def __init__(self, exc=None):
+        self.exc = exc or pymysql.ProgrammingError('Cursor closed')
+        self.rollbacks = 0
+
+    def cursor(self):
+        raise self.exc
+
+    def rollback(self):
+        self.rollbacks += 1
+
+
+def body_of(response):
+    return json.loads(response['body'])
+
+
+# (label, callable) — one entry per code path that formats a pymysql error.
+CRUD_PATHS = [
+    ('POST single', lambda conn: rest_post(
+        'POST', conn, 'darwin_dev', 'areas', {'area_name': 'x'}, None)),
+    ('POST bulk', lambda conn: rest_post(
+        'POST', conn, 'darwin_dev', 'areas', [{'area_name': 'x'}], None)),
+    ('PUT', lambda conn: rest_put(
+        'PUT', conn, 'darwin_dev', 'areas', [{'id': 1, 'area_name': 'x'}], None)),
+    ('DELETE single', lambda conn: rest_delete(
+        'DELETE', conn, 'darwin_dev', 'areas', {'id': 1}, None)),
+    ('DELETE bulk', lambda conn: rest_delete(
+        'DELETE', conn, 'darwin_dev', 'areas', [{'id': 1}], None)),
+    ('GET table', lambda conn: rest_get_table(
+        'GET', conn, 'darwin_dev', 'areas', {'queryStringParameters': None}, None)),
+    ('GET database', lambda conn: rest_get_database('GET', conn, 'darwin_dev')),
+]
+
+
+@pytest.mark.parametrize('label, call', CRUD_PATHS, ids=[p[0] for p in CRUD_PATHS])
+def test_a_one_arg_pymysql_error_yields_a_500_not_an_escaped_indexerror(label, call):
+    # The assertion that matters is simply that this RETURNS. Before the fix the
+    # IndexError propagated out of `call` and pytest reported an error, not a
+    # failure — which is exactly how it stayed invisible in production as a 503.
+    response = call(OneArgErrorConn())
+
+    assert response['statusCode'] == 500, label
+    # The driver's text still reaches the client. pymysql puts a one-arg error's
+    # message in args[0], so it lands in the errno slot — odd-looking, but it
+    # NAMES the failure, which the swallowed 503 never did.
+    assert 'Cursor closed' in body_of(response), label
+
+
+@pytest.mark.parametrize('label, call', CRUD_PATHS, ids=[p[0] for p in CRUD_PATHS])
+def test_a_zero_arg_pymysql_error_also_returns(label, call):
+    response = call(OneArgErrorConn(pymysql.Error()))
+    assert response['statusCode'] == 500, label
+
+
+@pytest.mark.parametrize('label, call', [p for p in CRUD_PATHS if 'bulk' in p[0]],
+                         ids=[p[0] for p in CRUD_PATHS if 'bulk' in p[0]])
+def test_the_bulk_paths_still_roll_back_before_reporting(label, call):
+    """The rollback must not be skipped by the error-formatting change.
+
+    Both bulk paths issue ONE multi-value statement, so a failure there leaves a
+    partially-applied transaction if nothing rolls it back.
+    """
+    conn = OneArgErrorConn()
+    call(conn)
+    assert conn.rollbacks == 1, label
+
+
+def test_a_one_arg_error_is_never_mistaken_for_a_conflict():
+    """The 409 gate must not fire on an error with no errno.
+
+    `integrity_errno` sees the string 'Cursor closed' in the errno slot. It is
+    hashable and not in INTEGRITY_ERRNOS, so it returns None — but if that ever
+    regressed, the client would get a 409 promising that retrying with different
+    data can succeed, for a dead cursor.
+    """
+    for label, call in CRUD_PATHS:
+        response = call(OneArgErrorConn())
+        assert response['statusCode'] != 409, label


### PR DESCRIPTION
## Summary
- wip(Lambda-Rest): 2026-07-26T10:01:55Z
- wip(Lambda-Rest): 2026-07-26T09:57:39Z
- chore: init swarm session feature/3059-map-pymysql-integrityerror-to-http-1

## Files changed
```
 CLAUDE.md                              |  42 +++++++-
 rest_api_utils.py                      | 109 +++++++++++++++++++-
 rest_delete.py                         |  13 ++-
 rest_get_database.py                   |   5 +-
 rest_get_table.py                      |   8 +-
 rest_post.py                           |  17 +++-
 rest_put.py                            |   8 +-
 tests/test_agent_instructions.py       |  74 +++++++++-----
 tests/test_error_paths.py              |  32 +++---
 tests/test_instructions.py             |  74 ++++++++++----
 tests/test_unit_conflict.py            | 177 +++++++++++++++++++++++++++++++++
 tests/test_unit_error_detail_wiring.py | 117 ++++++++++++++++++++++
 12 files changed, 607 insertions(+), 69 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
Related PRs (req #3059, one change across three repos): BillWilliams79/DarwinAI-Config#645 · BillWilliams79/Darwin#843 · BillWilliams79/AWS-Lambda-REST-API#55