### PR TITLE
Junction POST returns 500 after committing the row (breaks Features linking UI)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,10 +40,12 @@ AWS Lambda function serving a REST API backed by MySQL (RDS) via API Gateway pro
 - Returns `row[0]` (a tuple) to `compose_rest_response` — causes double-encoding
 
 ### rest_post.py
-- Accepts a single object (dict) body, not an array
-- INSERT into table, then SELECT LAST_INSERT_ID(), then re-reads the full row using JSON_OBJECT and returns it
-- Three separate try/except blocks: insert, get ID, read-back
-- On partial failure (insert succeeds but read-back fails), returns 201 with empty body
+- Accepts a single object (dict) body, or an array (bulk path, `_rest_post_bulk`)
+- Single object: INSERT into table, then `DESC {table}`, then SELECT LAST_INSERT_ID(), then re-reads the full row using JSON_OBJECT and returns it (200)
+- Four separate try/except blocks: insert, DESC, get ID, read-back
+- **The INSERT is the only step that can produce a 500.** Once it commits (autocommit), every later step — DESC, LAST_INSERT_ID, the read-back, and any `pymysql.Error` out of any of them — degrades to `201 CREATED` with an empty body. Reporting a committed row as a failed write is what req #3057 fixed; a lost connection or a read timeout during the read-back is the same lie under a different error code
+- **A table with no `id` column skips the read-back entirely** and returns 201 — that is every junction table (composite PK). The `DESC` runs before LAST_INSERT_ID precisely so the column list is available to make that call (req #3057)
+- Array body: one multi-value INSERT, no read-back, `201 {"inserted": N, "first_id": M}`. The whole statement rolls back on failure
 - Returns `row[0]` (tuple) to `compose_rest_response` — causes double-encoding
 
 ### rest_put.py

--- a/rest_post.py
+++ b/rest_post.py
@@ -51,6 +51,34 @@ def rest_post(post_method, conn, database, table, body, authenticated_user=None)
         print(errorMsg)
         return compose_rest_response(500, '', errorMsg)
 
+    # The INSERT has committed (autocommit). Everything below is the read-back,
+    # which is a convenience for the caller — never a reason to report failure.
+    try:
+        # retrieve table description and create json object and sql columns
+        with conn.cursor() as cursor:
+            cursor.execute(f""" DESC {table}; """)
+            rows = cursor.fetchall()
+
+        json_object_columns = ', '.join(f"'{row[0]}', {row[0]}" for row in rows)
+
+        sql_columns = []
+        for row in rows:
+            sql_columns.append(row[0])
+
+    except pymysql.Error as e:
+        # `{e}` not `{e.args[0]} {e.args[1]}` — see the read-back handler below.
+        print(f"HTTP {post_method} helper DESC SQL command failed: {e}")
+        return compose_rest_response(201, '', 'CREATED')
+
+    # No `id` column means the read-back below (`WHERE id=...`) cannot be built.
+    # That is every junction table (composite PK). The row is already committed,
+    # so the only correct answer is 201 CREATED without a body — reporting the
+    # missing column as a 500 told callers a successful write had failed
+    # (req #3057). Callers that need the row read it back by its composite key.
+    if 'id' not in sql_columns:
+        print(f"HTTP {post_method}: {table} has no id column, skipping read-back.")
+        return compose_rest_response(201, '', 'CREATED')
+
     try:
         # retrieve ID of newly created row
         sql_statement= f"""SELECT LAST_INSERT_ID()"""
@@ -64,24 +92,7 @@ def rest_post(post_method, conn, database, table, body, authenticated_user=None)
                 return compose_rest_response(201, '', 'CREATED')
 
     except pymysql.Error as e:
-        print(f"HTTP {post_method} FAILED to read last_insert_id: {e.args[0]} {e.args[1]}")
-        return compose_rest_response(201, '', 'CREATED')
-
-    try:
-        # retrieve table description and create json object and sql columns
-        with conn.cursor() as cursor:
-            cursor.execute(f""" DESC {table}; """)
-            rows = cursor.fetchall()
-
-        json_object_columns = ', '.join(f"'{row[0]}', {row[0]}" for row in rows)
-
-        sql_columns = []
-        for row in rows:
-            sql_columns.append(row[0])
-        
-    except pymysql.Error as e:
-        errorMsg = f"HTTP {post_method} helper DESC SQL command failed: {e.args[0]} {e.args[1]}"
-        print(errorMsg)
+        print(f"HTTP {post_method} FAILED to read last_insert_id: {e}")
         return compose_rest_response(201, '', 'CREATED')
 
     try:
@@ -111,9 +122,15 @@ def rest_post(post_method, conn, database, table, body, authenticated_user=None)
             return compose_rest_response(201, '', 'CREATED')
 
     except pymysql.Error as e:
-        errorMsg = f"HTTP {post_method} helper SELECT after WRITE SQL command failed: {e.args[0]} {e.args[1]}"
-        print(errorMsg)
-        return compose_rest_response(500, '', errorMsg)
+        # The row committed under autocommit before this SELECT ran, so NO
+        # failure here is a failed write — 500 would repeat req #3057's defect
+        # under a different error code (a lost connection or a read timeout
+        # between the INSERT and the read-back reaches exactly this line). The
+        # cause is logged; the caller is told the truth, which is CREATED.
+        # `{e}` not `{e.args[0]} {e.args[1]}`: InterfaceError carries a single
+        # arg, and indexing args[1] raised IndexError out of the except block.
+        print(f"HTTP {post_method} helper SELECT after WRITE SQL command failed: {e}")
+        return compose_rest_response(201, '', 'CREATED')
 
     return compose_rest_response(500, '', 'INVALID PATH')
 

--- a/tests/test_agent_instructions.py
+++ b/tests/test_agent_instructions.py
@@ -1,21 +1,21 @@
-"""REST contracts for the `agent_instructions` junction (req #3049).
+"""REST contracts for the `agent_instructions` junction (req #3049, #3057).
 
-This table has a composite PK and NO `id` column, which makes the generic
-passthrough behave in two ways the Darwin UI must be written around. Both are
-locked here because both are invisible until something depends on them:
+This table has a composite PK and NO `id` column. Both insert paths are locked
+here because neither is visible from the table definition alone:
 
-1. **A SINGLE-OBJECT POST COMMITS THE ROW AND THEN RETURNS 500.** `rest_post.py`
-   re-reads the new row with `SELECT ... WHERE id = <LAST_INSERT_ID()>`, which
-   raises 1054 on a table with no `id` column — after the INSERT has already
-   committed under autocommit. The caller sees a failure that actually succeeded.
-   The test below asserts BOTH halves on purpose. Do not "fix" it into a silent
-   regression: `test_swarm_starts.py` documents the same read-back assumption,
-   and the fix belongs in `rest_post.py`, not here.
+1. **A SINGLE-OBJECT POST RETURNS 201 WITH NO BODY.** `rest_post.py` reads the
+   new row back with `SELECT ... WHERE id = <LAST_INSERT_ID()>`, which no
+   `id`-less table can answer. Req #3057 made it consult the `DESC` column list
+   it already has and skip the read-back instead — before that it raised 1054
+   and returned 500 for a row that had already committed under autocommit, so
+   every caller saw a successful write as a failure. The 201 asserted below is
+   the whole fix: assert the status AND the committed row, because a regression
+   here is silent in either direction.
 
-2. **An ARRAY body works.** `_rest_post_bulk` does no read-back, so it returns
-   201 `{"inserted": N}`. That is the ONLY sound insert path for this table and
-   the one `Darwin/src/Agents/actions/instructionsApi.js` uses for every link,
-   including single links.
+2. **An ARRAY body returns 201 `{"inserted": N}`.** `_rest_post_bulk` never
+   read back, so this path was always sound. It is one round trip for N links,
+   which is why `Darwin/src/Agents/actions/instructionsApi.js` keeps using it
+   for every link, single links included.
 
 PUT is impossible (rest_put.py requires `id`), so a load-order change is a
 DELETE + re-POST. `DELETE {agent_fk}` clearing one agent's whole list is the
@@ -103,13 +103,15 @@ class TestAgentInstructionsInsert:
         assert [(r['instruction_fk'], r['sort_order']) for r in rows] == \
             [(first, 1), (second, 2)]
 
-    def test_single_object_post_returns_500_but_commits_the_row(
+    def test_single_object_post_returns_201_and_commits_the_row(
             self, invoke, registry, db_connection):
-        """Known-bad, deliberately locked. See this module's docstring.
+        """req #3057. See this module's docstring.
 
-        The row IS created; only the read-back fails. A caller that retries on
-        this "failure" gets a duplicate-key error on the second attempt, which is
-        exactly why the UI never uses the single-object path.
+        Both halves matter. The status must be 201 — a 500 here is the old bug,
+        which made callers treat a committed row as a failed write and retry
+        into a duplicate-key error. The body must stay empty — there is no
+        `id` to read the row back by, so the gateway has nothing honest to
+        return and callers re-read by composite key.
         """
         agent = registry['agent']('single')
         instruction = registry['instruction']('single-a')
@@ -117,11 +119,31 @@ class TestAgentInstructionsInsert:
         resp = invoke('POST', '/darwin_dev/agent_instructions', body={
             'agent_fk': agent, 'instruction_fk': instruction, 'sort_order': 1,
         })
-        assert resp['statusCode'] == 500
-        assert '1054' in _err(resp)
+        assert resp['statusCode'] == 201, resp['body']
+        assert json.loads(resp['body']) == ''
 
         rows = _links(db_connection, agent)
-        assert [r['instruction_fk'] for r in rows] == [instruction]
+        assert [(r['instruction_fk'], r['sort_order']) for r in rows] == \
+            [(instruction, 1)]
+
+    def test_single_object_post_duplicate_is_still_500_with_1062(
+            self, invoke, registry):
+        """The 201 is scoped to the read-back, not to INSERT errors.
+
+        `rest_post.py` returns early on an INSERT failure, so skipping the
+        read-back cannot swallow one. If this ever returns 201 the guard has
+        been moved above the INSERT's error handling and every junction write
+        has become unverifiable.
+        """
+        agent = registry['agent']('single-dupe')
+        instruction = registry['instruction']('single-dupe-a')
+        body = {'agent_fk': agent, 'instruction_fk': instruction, 'sort_order': 1}
+
+        assert invoke('POST', '/darwin_dev/agent_instructions',
+                      body=dict(body))['statusCode'] == 201
+        resp = invoke('POST', '/darwin_dev/agent_instructions', body=dict(body))
+        assert resp['statusCode'] == 500
+        assert '1062' in _err(resp)
 
     def test_duplicate_link_is_500_with_1062(self, invoke, registry):
         agent = registry['agent']('dupe')

--- a/tests/test_swarm_starts.py
+++ b/tests/test_swarm_starts.py
@@ -5,8 +5,9 @@ any per-table code change. Mirrors test_crud_lifecycle.py.
 
 The junction table swarm_start_sessions is canonically written via the MCP
 tool `link_swarm_start_session`, not via REST — its cascade behavior is
-covered by DarwinSQL/tests/test_cascades.py. (Generic POST to junction
-tables fails the read-back because rest_post.py assumes an `id` column.)
+covered by DarwinSQL/tests/test_cascades.py. (Generic POST to a junction table
+returns 201 with no body: rest_post.py skips its `WHERE id=...` read-back on a
+table that has no `id` column. See test_agent_instructions.py, req #3057.)
 """
 import json
 import pytest


### PR DESCRIPTION
## Summary
- wip(Lambda-Rest): 2026-07-26T09:10:26Z
- chore: init swarm session feature/3057-junction-post-returns-500-after-1

## Files changed
```
 CLAUDE.md                        | 10 +++---
 rest_post.py                     | 59 +++++++++++++++++++++-------------
 tests/test_agent_instructions.py | 68 ++++++++++++++++++++++++++--------------
 tests/test_swarm_starts.py       |  5 +--
 4 files changed, 92 insertions(+), 50 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)