### PR TITLE
Per-document actual-token capture for architecture/autoload docs

### DIFF
--- a/auth_utils.py
+++ b/auth_utils.py
@@ -61,6 +61,9 @@ CREATOR_FK_TABLES = frozenset({
     # and the per-agent rows carry creator_fk; scope generic passthrough to the
     # authenticated user.
     'agent_telemetry_runs', 'agent_telemetry_rows',
+    # Req #3096 — per-document actual-token rows (migration 074). Carries
+    # creator_fk like its parent row; scope generic passthrough the same way.
+    'agent_telemetry_row_docs',
 })
 
 PROFILE_TABLE = 'profiles'


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/AWS-Lambda-REST-API into feature/3096-per-document-actual-token-capture-1
- wip(Lambda-Rest): 2026-07-26T12:40:14Z
- chore: init swarm session feature/3096-per-document-actual-token-capture-1

## Files changed
```
 auth_utils.py | 3 +++
 1 file changed, 3 insertions(+)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)