### PR TITLE
Pipeline 2.0 - the five parallel plan-layer tables, registration and test surfaces

### DIFF
--- a/auth_utils.py
+++ b/auth_utils.py
@@ -240,6 +240,15 @@ CREATOR_FK_TABLES = frozenset({
     # somebody else's live reservation — which is not a leak but a way to make
     # two orchestrators believe they both hold a scope.
     'orchestration_claims',
+    # Req #3337 — Pipeline 2.0 plan layer (migration 20260808115509). The
+    # parallel-era images of epics/pipelines/pipeline_steps: each carries a NOT
+    # NULL creator_fk, so membership here is what makes the generic passthrough
+    # work at all, exactly as for the #3111 three above.
+    #
+    # pipeline2_step_requirements and pipeline2_step_deps stay OUT: neither has
+    # a creator_fk. They inherit ownership from their step, in JUNCTION_OWNERSHIP
+    # below.
+    'pipeline2_pipelines', 'pipeline2_epics', 'pipeline2_steps',
 })
 
 PROFILE_TABLE = 'profiles'
@@ -305,6 +314,20 @@ JUNCTION_OWNERSHIP = {
     },
     'pipeline_step_requirements': {
         'scope': ('step_fk', 'pipeline_steps'),
+        'verify': (('requirement_fk', 'requirements'),),
+    },
+
+    # Pipeline 2.0 plan layer (req #3337, migration 20260808115509). Identical
+    # shape to the 1.0 pair above and for identical reasons. `dep_step_fk` needs
+    # `verify` because it is ON DELETE RESTRICT: a cross-tenant edge would make
+    # somebody else's step undeletable, a denial of service rather than merely a
+    # leak.
+    'pipeline2_step_deps': {
+        'scope': ('step_fk', 'pipeline2_steps'),
+        'verify': (('dep_step_fk', 'pipeline2_steps'),),
+    },
+    'pipeline2_step_requirements': {
+        'scope': ('step_fk', 'pipeline2_steps'),
         'verify': (('requirement_fk', 'requirements'),),
     },
 
@@ -447,7 +470,7 @@ UNSCOPED_TABLES = frozenset()
 # COLUMNS DELIBERATELY NOT HERE. `creator_fk` itself (forced from the token, and
 # the only FK on these tables that targets `profiles`), and any FK whose target
 # is NOT creator-scoped — there is nobody to steal from. As of migration
-# 20260801150404 there are no such columns: all 41 non-`creator_fk` FKs on the 39
+# 20260808115509 there are no such columns: all 45 non-`creator_fk` FKs on the 42
 # creator-scoped tables target creator-scoped tables.
 #
 # ADDING A COLUMN. You do not — `test_every_cross_tenant_fk_column_is_registered`
@@ -513,6 +536,16 @@ CREATOR_TABLE_REFERENCES = {
     ),
     'pipeline_steps': (
         ('pipeline_fk', 'pipelines'),                        # CASCADE
+    ),
+    'pipeline2_epics': (                                     # req #3337
+        ('pipeline_fk', 'pipeline2_pipelines'),              # CASCADE
+        ('category_fk', 'categories'),                       # RESTRICT
+    ),
+    'pipeline2_pipelines': (                                 # req #3337
+        ('machine_fk', 'machines'),                          # RESTRICT
+    ),
+    'pipeline2_steps': (                                     # req #3337
+        ('epic_fk', 'pipeline2_epics'),                      # CASCADE
     ),
     'pipelines': (
         ('machine_fk', 'machines'),                          # RESTRICT

--- a/tests/test_creator_fk_references_exhaustive.py
+++ b/tests/test_creator_fk_references_exhaustive.py
@@ -83,6 +83,11 @@ def _required_columns(table, seed):
         'orchestration_claims': {},
         'pipeline_steps': {'title': f'{seed}-step'},
         'pipelines': {'title': f'{seed}-pipeline'},
+        # Req #3337. Like `epics`/`pipelines` above, the only NOT NULL,
+        # no-default, non-reference column each carries is `title`.
+        'pipeline2_pipelines': {'title': f'{seed}-p2pipeline'},
+        'pipeline2_epics': {'title': f'{seed}-p2epic'},
+        'pipeline2_steps': {'title': f'{seed}-p2step'},
         'recurring_tasks': {'description': f'{seed}-rt', 'recurrence': 'daily',
                             'anchor_date': '2026-07-27'},
         'requirements': {'title': f'{seed}-req', 'ai_model': 'opus',
@@ -106,17 +111,20 @@ def seed_int(seed):
     return abs(hash(seed)) % 100000 + 1
 
 
+# COVERS: SCH-016
 def test_the_matrix_is_the_whole_registry():
     """Guard the guard: a generation bug would make every case below vacuous."""
     assert len(TRIPLES) == sum(len(v) for v in CREATOR_TABLE_REFERENCES.values())
     # 36 at req #3125, 38 at #3186 (which added the two `swarm_sessions`
     # attribution FKs and left this literal at 36 — it has been failing since),
-    # 41 at #3224's three `orchestration_claims` columns.
-    assert len(TRIPLES) == 41, f'expected 41 registered columns, generated {len(TRIPLES)}'
-    assert len(PARENTS) == 22, PARENTS
+    # 41 at #3224's three `orchestration_claims` columns, 45 at #3337's four
+    # Pipeline 2.0 plan-layer columns.
+    assert len(TRIPLES) == 45, f'expected 45 registered columns, generated {len(TRIPLES)}'
+    assert len(PARENTS) == 24, PARENTS
     assert ('test_runs', 'test_plan_fk', 'test_plans') in TRIPLES
 
 
+# COVERS: SCH-016
 def test_every_table_in_the_registry_has_a_body_template():
     """A new registered table must fail HERE, not as a confusing KeyError inside
     a parametrized case where it would look like an authorization result."""
@@ -140,6 +148,7 @@ PURGE_ORDER = (
     'agent_telemetry_row_docs', 'agent_telemetry_rows', 'agent_telemetry_runs',
     'customer_releases', 'dev_servers', 'swarm_undos',
     'pipeline_steps', 'pipelines',
+    'pipeline2_steps', 'pipeline2_epics', 'pipeline2_pipelines',
     'test_results', 'test_runs', 'test_plans', 'test_cases',
     'requirements', 'features', 'epics',
     'tasks', 'recurring_tasks', 'areas', 'domains',
@@ -179,7 +188,7 @@ def _make_invoke(sub):
 
 
 def _build_graph(invoke, seed):
-    """One owned row in each of the 22 parent tables, created THROUGH the gateway.
+    """One owned row in each of the 24 parent tables, created THROUGH the gateway.
 
     Doubling as the owner-side regression proof: every one of these POSTs now
     runs the ownership guard, so a rule that over-refuses fails here before any
@@ -209,6 +218,7 @@ def _build_graph(invoke, seed):
     post('swarm_starts', req('swarm_starts'))
     post('pipelines', req('pipelines'))
     post('agent_telemetry_runs', req('agent_telemetry_runs'))
+    post('pipeline2_pipelines', req('pipeline2_pipelines'))
 
     # One level down.
     post('categories', dict(req('categories'), project_fk=ids['projects']))
@@ -223,11 +233,15 @@ def _build_graph(invoke, seed):
     post('test_cases', dict(req('test_cases'), category_fk=ids['categories']))
     post('recurring_tasks', dict(req('recurring_tasks'), area_fk=ids['areas']))
     post('builds', dict(req('builds'), branch_fk=ids['branches']))
+    post('pipeline2_epics', dict(req('pipeline2_epics'),
+                                 pipeline_fk=ids['pipeline2_pipelines'],
+                                 category_fk=ids['categories']))
 
     # Three.
     post('features', dict(req('features'), category_fk=ids['categories']))
     post('requirements', dict(req('requirements'), category_fk=ids['categories']))
     post('test_runs', dict(req('test_runs'), test_plan_fk=ids['test_plans']))
+    post('pipeline2_steps', dict(req('pipeline2_steps'), epic_fk=ids['pipeline2_epics']))
 
     missing = [p for p in PARENTS if p not in ids]
     assert not missing, f'{seed} graph is missing parent rows for {missing}'
@@ -326,10 +340,13 @@ def _value(conn, table, row_id, column):
 # POST — every column
 # ---------------------------------------------------------------------------
 
+# COVERS: SCH-017
 @pytest.mark.parametrize('triple', TRIPLES, ids=[_tid(t) for t in TRIPLES])
 def test_post_naming_a_victim_parent_is_refused(triple, victim_graph,
                                                 attacker_graph, db_connection):
-    """36 cases. The attacker's own, otherwise-valid row, aimed at the victim.
+    """45 cases (four of them #3337's, against a victim-owned
+    pipeline2_pipelines -> pipeline2_epics chain built by `_build_graph`). The
+    attacker's own, otherwise-valid row, aimed at the victim.
 
     `creator_fk` is forced from the attacker's token, so nothing else in the
     gateway objects — this is the whole vulnerability in one request.
@@ -354,11 +371,12 @@ def test_post_naming_a_victim_parent_is_refused(triple, victim_graph,
 # PUT — every column
 # ---------------------------------------------------------------------------
 
+# COVERS: SCH-017
 @pytest.mark.parametrize('triple', TRIPLES, ids=[_tid(t) for t in TRIPLES])
 def test_put_repointing_at_a_victim_parent_is_refused(triple, victim_graph,
                                                       attacker_graph,
                                                       db_connection):
-    """36 more. The row is genuinely the attacker's, so the `creator_fk = %s`
+    """45 more. The row is genuinely the attacker's, so the `creator_fk = %s`
     predicate passes and only the SET clause is hostile — the door that stays
     open if POST alone is guarded."""
     table, column, parent = triple

--- a/tests/test_unit_creator_fk_references.py
+++ b/tests/test_unit_creator_fk_references.py
@@ -153,11 +153,15 @@ def test_the_schema_parse_actually_found_foreign_keys(schema, creator_scoped):
     assert ('test_plan_fk', 'test_plans', 'RESTRICT') in schema['test_runs']['fks']
 
 
+# COVERS: SCH-013
 def test_the_ddl_and_the_registry_agree_on_which_tables_carry_creator_fk(creator_scoped):
     """`CREATOR_FK_TABLES` is the input to the derivation, so it must be right.
 
     Already covered from the darwin-mcp side; asserted here because every test
-    below reads it as the definition of "creator-scoped".
+    below reads it as the definition of "creator-scoped". Derived from
+    schema.sql, so it fails helpfully if pipeline2_pipelines/_epics/_steps are
+    missing, or if either pipeline2_ edge table (no creator_fk) is wrongly
+    present.
     """
     assert creator_scoped == set(CREATOR_FK_TABLES), {
         'in schema.sql only': sorted(creator_scoped - CREATOR_FK_TABLES),
@@ -169,12 +173,15 @@ def test_the_ddl_and_the_registry_agree_on_which_tables_carry_creator_fk(creator
 # Completeness — the test that stops the next grief-lock
 # ---------------------------------------------------------------------------
 
+# COVERS: SCH-015
 def test_every_cross_tenant_fk_column_is_registered(schema, creator_scoped):
     """THE invariant of req #3125, re-derived from the DDL on every run.
 
     An unregistered column is one POST away from pinning a victim's row forever.
     The previous audit of this exact class hand-counted eleven columns; the DDL
-    says thirty-six. This is why the list is derived and not reviewed.
+    says thirty-six — now forty-five, with #3337's four pipeline2_epics/
+    pipeline2_pipelines/pipeline2_steps columns. This is why the list is
+    derived and not reviewed.
     """
     expected = set(_cross_tenant_fk_columns(schema, creator_scoped))
     missing = sorted(expected - set(_registered()) - set(UNCHECKED_CREATOR_REFERENCES))

--- a/tests/test_unit_junction_scoping.py
+++ b/tests/test_unit_junction_scoping.py
@@ -90,12 +90,16 @@ def test_schema_parse_found_the_tables(schema):
     assert schema['requirements']['has_creator_fk']
 
 
+# COVERS: SCH-014
 def test_every_unscoped_table_is_registered(schema):
     """Every table without creator_fk must be in JUNCTION_OWNERSHIP.
 
     THE invariant of req #3122. `profiles` is scoped by `id` and is the one
     permitted special case; `UNSCOPED_TABLES` is the written-down escape hatch and
     is empty. Anything else absent from both is unscoped on GET/PUT/DELETE/POST.
+    Derived from schema.sql, so it fails helpfully if pipeline2_step_deps or
+    pipeline2_step_requirements (neither carries creator_fk) is missing from
+    JUNCTION_OWNERSHIP.
     """
     unscoped = {name for name, info in schema.items()
                 if not info['has_creator_fk'] and name != PROFILE_TABLE}


### PR DESCRIPTION
## Summary
- wip(Lambda-Rest): 2026-08-08T12:52:42Z
- chore: init swarm session feature/3337-pipeline-20-the-five-parallel-plan-1

## Files changed
```
 auth_utils.py                                  | 35 +++++++++++++++++++++++++-
 tests/test_creator_fk_references_exhaustive.py | 30 +++++++++++++++++-----
 tests/test_unit_creator_fk_references.py       | 11 ++++++--
 tests/test_unit_junction_scoping.py            |  4 +++
 4 files changed, 71 insertions(+), 9 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)