### PR TITLE
Pipeline 2.0 - the requirement_test_cases junction and the re-homed MCP test-case surface

### DIFF
--- a/auth_utils.py
+++ b/auth_utils.py
@@ -353,6 +353,13 @@ JUNCTION_OWNERSHIP = {
         'scope': ('feature_fk', 'features'),
         'verify': (('test_case_fk', 'test_cases'),),
     },
+    # Pipeline 2.0 Feature retirement — test cases re-home onto Requirement
+    # (req #3352, migration 20260809002149). Stands beside `feature_test_cases`
+    # above, not in its place, until req #3334's eradication sequencing.
+    'requirement_test_cases': {
+        'scope': ('requirement_fk', 'requirements'),
+        'verify': (('test_case_fk', 'test_cases'),),
+    },
     'test_plan_cases': {
         'scope': ('test_plan_fk', 'test_plans'),
         'verify': (('test_case_fk', 'test_cases'),),

--- a/tests/test_requirement_test_cases_gateway_routing.py
+++ b/tests/test_requirement_test_cases_gateway_routing.py
@@ -1,0 +1,57 @@
+"""requirement_test_cases API Gateway routing — Lambda-side half (req #3352).
+
+# COVERS: SCH-033
+
+Mirrors test_pipeline2_gateway_routing.py's split for the same reason: SCH-033
+("both requirement_test_cases gateway routes exist and answer") splits into a
+Lambda-side half assertable here and an AWS-wiring half that is not.
+
+- **The Lambda-side half — asserted HERE.** `lambda_handler` correctly parses
+  `/darwin_dev/requirement_test_cases`, applies `auth_utils` registration
+  (`JUNCTION_OWNERSHIP`), and executes a real SQL query against `darwin_dev`,
+  proving no application-level obstacle would make the route fail once the AWS
+  wiring is in place. Exercised via `/darwin_dev/*` only — this suite's
+  existing convention (`invoke`'s own docstring example in `conftest.py`) is
+  to never touch `/darwin/*` production data from a test, and production has
+  no `requirement_test_cases` table yet regardless (req #3352 body item 2 —
+  a later requirement's gate).
+- **The AWS-wiring half — NOT assertable from any repository, by design.**
+  Whether both resources (`/darwin/requirement_test_cases` and
+  `/darwin_dev/requirement_test_cases`) are actually deployed in API Gateway
+  is not something source control can prove — API Gateway is console-built
+  with no IaC. Both were created via `DarwinSQL/scripts/add-api-route.sh`
+  (`--database=darwin_dev` and `--database=darwin`) and confirmed present via
+  `add-api-route.sh --list` at creation time.
+
+Requires `exports.sh` (real `darwin_dev` connection), consistent with every
+other CRUD-style test in this directory.
+"""
+import pytest
+
+
+class TestRequirementTestCasesAnswers:
+    """SCH-033 (Lambda-side half): requirement_test_cases is reachable
+    end-to-end through `lambda_handler` — path parsing, `auth_utils`
+    registration, and a real SQL query against `darwin_dev`.
+
+    A well-formed answer here is 200 (rows present) or 404 "NOT FOUND" (the
+    documented empty-result shape for a GET matching zero rows — see
+    `memory/lambda-patterns.md` § "A GET returning no rows is a 404"). Neither
+    is a routing or wiring failure; a 400/403/500/503 would be.
+    """
+
+    @pytest.mark.integration
+    def test_get_answers_without_error(self, invoke):
+        response = invoke('GET', '/darwin_dev/requirement_test_cases')
+        assert response['statusCode'] in (200, 404), (
+            f"/darwin_dev/requirement_test_cases returned "
+            f"{response['statusCode']}, expected 200 (rows) or 404 (documented "
+            f"empty-result shape): {response.get('body')}"
+        )
+        if response['statusCode'] == 404:
+            assert response['body'] == '"NOT FOUND"', (
+                f"/darwin_dev/requirement_test_cases 404 body was "
+                f"{response['body']!r}, not the documented empty-result shape "
+                f"— this would indicate a real routing/auth failure disguised "
+                f"as the expected empty case"
+            )

--- a/tests/test_unit_creator_fk_references.py
+++ b/tests/test_unit_creator_fk_references.py
@@ -24,6 +24,8 @@ security boundary drifts silently — `test_every_cross_tenant_fk_column_is_regi
 re-derives it on every run, so a new FK column fails the build instead.
 
 Everything here runs without a database or `exports.sh`.
+
+# COVERS: SCH-032
 """
 import os
 import re

--- a/tests/test_unit_junction_scoping.py
+++ b/tests/test_unit_junction_scoping.py
@@ -15,6 +15,8 @@ nothing if the parent is itself unscoped, or if the column named does not exist,
 so both are checked against the DDL rather than trusted.
 
 Everything here runs without a database or `exports.sh`.
+
+# COVERS: SCH-032
 """
 import os
 import re


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/AWS-Lambda-REST-API into feature/3352-pipeline-20-the-requirement-test-1
- wip(Lambda-Rest): 2026-08-09T01:49:53Z
- chore: init swarm session feature/3352-pipeline-20-the-requirement-test-1

## Files changed
```
 auth_utils.py                                      |  7 +++
 .../test_requirement_test_cases_gateway_routing.py | 57 ++++++++++++++++++++++
 tests/test_unit_creator_fk_references.py           |  2 +
 tests/test_unit_junction_scoping.py                |  2 +
 4 files changed, 68 insertions(+)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Related PRs: BillWilliams79/DarwinAI-Config#903, BillWilliams79/DarwinSQL#129