### PR TITLE
Empty string stored in ai_model / effort NOT NULL enums

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,9 @@ AWS Lambda function serving a REST API backed by MySQL (RDS) via API Gateway pro
 
 `auth_utils.py` answers *who owns this row* for the whole gateway (req #3122),
 and separately *who owns the rows it references* (req #3125). The second is not
-implied by the first — see § Outbound references below.
+implied by the first — see § Outbound references below. A fifth registry in the
+same file answers a different question entirely — *may this column be written
+blank* — and is documented under § Bounded value domains (req #3432).
 
 | Registry | Applies when | Predicate injected |
 |---|---|---|
@@ -185,6 +187,69 @@ fails the build until registered. `UNCHECKED_CREATOR_REFERENCES` is the
 written-down exemption set and is empty. Cross-tenant coverage is
 `tests/test_creator_fk_references.py` (21 tests; 16 fail without the fix, the
 other 5 being victim-side regression tests that must pass either way).
+
+## Bounded value domains — a NOT NULL enum is never written BLANK (req #3432)
+
+`ENUM_COLUMNS` is the fifth registry in `auth_utils.py` and the only one that is not
+about authorization. It answers *is the empty string a legitimate value for this
+column*, and for a column whose value set is `haiku|sonnet|opus|fable` the answer is
+always no. `check_enum_blanks()` refuses a write that NAMES such a column and supplies
+`''`, whitespace, JSON `null`, or the `"NULL"` clear-sentinel — **400**, before any
+statement runs, on `rest_post` (single + bulk) and `rest_put`. Not on `rest_delete`:
+there a body key is a WHERE filter, and `ai_model=''` is a legitimate query.
+
+**`''` is a legal VARCHAR, which is the whole problem.** Nothing in the schema forbids
+it, this RDS instance runs a non-strict `sql_mode` (`NO_ENGINE_SUBSTITUTION`), and every
+reader that switches on the enum then matches no branch. Measured in production
+2026-08-09: 18 `requirements` rows carried `ai_model=''` and/or `effort=''`, and
+`/swarm-start` reads those two columns straight into the launch command — an affected
+requirement launches as `claude --model '' --effort ''`.
+
+**The mechanism that produced those rows is the OTHER one, deliberately.** They came
+from OMISSION — `requirements.ai_model` and `.effort` are the only enum columns in the
+schema with no column `DEFAULT`, so an INSERT that does not name them gets MySQL's
+implicit empty-string fill. Req #3434 closes that by giving both a `DEFAULT`, which is
+why **an absent key is untouched here**: on a POST it means "take the column default",
+on a PUT "unchanged". This registry closes the door #3434 does not — a caller that sends
+the key with nothing in it. No such caller existed in the codebase when this was written;
+it lives at the gateway precisely because the gateway is the single DB gateway and is the
+only place that covers the writer nobody has written yet.
+
+**Only blank is refused, never the domain.** The allowed values are deliberately not
+stored: a value list this file did not enforce would drift from darwin-mcp, which does
+enforce them, and a value list it DID enforce would refuse a new enum member the day it
+ships in code and before it is copied here. Blank is the one value that is wrong under
+every version of every domain.
+
+**Keys are read with `body_column()`**, so `{"AI_MODEL": ""}` is caught — the § *A body's
+KEYS are SQL identifiers* rule, which had already defeated two other registries.
+`check_body_keys` runs first on every path, so at most one spelling can match.
+
+**The candidates are DERIVED, the classification is written down.**
+`tests/test_unit_enum_blank.py` re-parses `schema.sql` for every NOT NULL column that is
+a real `ENUM(...)` or a CHAR/VARCHAR no wider than 32 — 46 columns today — and fails
+unless each is in `ENUM_COLUMNS` or `FREE_TEXT_NOT_NULL_COLUMNS` (41 + 5). A new enum
+column fails the build until registered.
+
+**That width rule is a FILTER, NOT A PROOF, and the difference is load-bearing.** It
+sweeps the shapes an enum is usually written in; a bounded domain declared wider is real
+and simply will not be swept. Two are — `swarm_completes.skill_name` VARCHAR(64)
+(`VALID_COMPLETE_SKILL_NAMES`, two members) and `user_integrations.provider` VARCHAR(50)
+(`'strava'`) — both accepted `''` silently until they were **registered by hand**, which
+brings `ENUM_COLUMNS` to **43 columns across 28 tables**. The test asks a different
+question of those: they are checked to EXIST in the DDL, not to have been swept. Raising
+the bound instead would drag in every VARCHAR(64) name and `creator_fk` itself, trading a
+reviewable exemption list for an unreviewable one. NOT NULL `TINYINT` flags are outside
+the registry altogether — `''` coerces to `0` there, a real member of the domain.
+
+Unlike `UNSCOPED_TABLES` and
+`UNCHECKED_CREATOR_REFERENCES`, the exemption set here is **not empty and cannot be** —
+the candidate rule is structural, so genuine free-text columns match it:
+`domains.domain_name`, `areas.area_name`, `map_views.name` (user-typed, and Darwin's
+"type into the blank row" pattern POSTs them empty), `map_runs.activity_name` (whatever
+the Cyclemeter/Strava/KML import found), `agents.ai_model` (the RESOLVED model id
+`opus[1m]`, which the schema comment marks as explicitly NOT the family enum — while
+`agents.effort` IS that family and is registered).
 
 ## Error Status Contract
 

--- a/auth_utils.py
+++ b/auth_utils.py
@@ -21,6 +21,11 @@ A fourth registry, `CREATOR_TABLE_REFERENCES`, answers the separate question
 "WHOSE ROW DOES THIS ROW POINT AT" for the tables in the first group. Scoping a
 row to its creator says nothing about the rows it REFERENCES, and every one of
 the three answers above is silent on that — which is the whole vulnerability.
+
+A fifth registry, `ENUM_COLUMNS` (req #3432), is not about authorization at all
+and lives here because this is where the gateway's per-column knowledge lives. It
+answers "IS THE EMPTY STRING A LEGITIMATE VALUE FOR THIS COLUMN" for every NOT
+NULL column with a bounded value domain, and the answer is always no.
 """
 
 import re
@@ -618,6 +623,190 @@ CREATOR_TABLE_REFERENCES = {
 # would refuse something legitimate. A pointer to a row the caller does not own,
 # on a column the database enforces, is not that.
 UNCHECKED_CREATOR_REFERENCES = frozenset()
+
+
+# ---------------------------------------------------------------------------
+# Bounded value domains — a NOT NULL enum must never be written BLANK (req #3432)
+# ---------------------------------------------------------------------------
+#
+# The fifth registry, and the only one here that is not about authorization. It
+# answers "IS THE EMPTY STRING A LEGITIMATE VALUE FOR THIS COLUMN", which for a
+# column whose value set is `haiku|sonnet|opus|fable` is always no.
+#
+# WHY THE GATEWAY HAS TO ANSWER IT. `''` is a perfectly legal VARCHAR value and
+# nothing in the schema forbids it, so MySQL stores it silently and every reader
+# that switches on the enum then matches no branch. Measured in production
+# 2026-08-09: 18 `requirements` rows carried `ai_model=''` and/or `effort=''`,
+# and `/swarm-start` reads those two columns straight into the launch command —
+# an affected requirement launches as `claude --model '' --effort ''`.
+#
+# THE MECHANISM THAT PRODUCED THEM IS NOT THIS ONE, AND THAT IS DELIBERATE. Those
+# rows came from OMISSION: this RDS instance runs a non-strict `sql_mode`
+# (`NO_ENGINE_SUBSTITUTION`, verified), so a NOT NULL column with no `DEFAULT`
+# that the INSERT does not name gets the implicit empty-string fill. Req #3434
+# closes that by giving the two columns a `DEFAULT` — an omitted key must keep
+# resolving to the column default, which is why an ABSENT key is untouched here.
+# This registry closes the other door: a caller that sends the key with nothing
+# in it. No such caller was found in the codebase when this was written, and that
+# is exactly why it belongs at the gateway rather than at a caller — the gateway
+# is the single DB gateway (CLAUDE.md), so it is the only place that covers the
+# writer nobody has written yet.
+#
+# ONLY BLANK IS REFUSED, NOT THE DOMAIN. The allowed values are deliberately NOT
+# stored here. A value list this file did not enforce would be dead data that
+# drifts from the application that does enforce it (darwin-mcp validates every
+# one of these on the way in); a value list this file DID enforce would refuse a
+# new enum member the day it ships in code and before it is copied here. Blank is
+# the one value that is wrong under every version of every domain.
+#
+# THE SET IS DERIVED, NEVER HAND-COUNTED — same discipline as
+# `CREATOR_TABLE_REFERENCES`. `tests/test_unit_enum_blank.py` re-derives the
+# CANDIDATES from `schema.sql` (NOT NULL, and either a real `ENUM(...)` or a
+# CHAR/VARCHAR no wider than 32) and fails unless every one is classified either
+# here or in `FREE_TEXT_NOT_NULL_COLUMNS` below. A new enum column fails the
+# build until it is registered.
+#
+# THAT WIDTH RULE IS A FILTER, NOT A PROOF, and saying so is the honest version
+# of the guarantee. It sweeps the shapes an enum is USUALLY written in; a bounded
+# domain declared wider is real and simply will not be swept, so it is registered
+# BY HAND and the test only checks it exists. Two are, today —
+# `swarm_completes.skill_name` VARCHAR(64) (`VALID_COMPLETE_SKILL_NAMES`, two
+# members) and `user_integrations.provider` VARCHAR(50) (`'strava'`) — and both
+# accepted `''` silently until they were listed here. Raising the bound instead
+# would drag in every VARCHAR(64) name and `creator_fk` itself, trading a
+# reviewable exemption list for an unreviewable one. NOT NULL `TINYINT` flags
+# (`requirements.tracking`, `closed`, `active`) are outside this registry
+# altogether: `''` coerces to `0` there, which is a real member of the domain.
+ENUM_COLUMNS = {
+    'acceptance_tests': frozenset({'acceptance_test_status'}),
+    'agent_telemetry_rows': frozenset({'role', 'session_kind'}),
+    'agent_telemetry_runs': frozenset({'ai_model', 'effort'}),
+    'agents': frozenset({'effort'}),
+    'architecture_documents': frozenset({'doc_type'}),
+    'areas': frozenset({'sort_mode'}),
+    'branches': frozenset({'branch_type'}),
+    'build_projects': frozenset({'project_status'}),
+    'categories': frozenset({'sort_mode'}),
+    'epics': frozenset({'epic_status'}),
+    'features': frozenset({'feature_status'}),
+    'machines': frozenset({'platform', 'arch'}),
+    'map_runs': frozenset({'source'}),
+    'pipeline2_epics': frozenset({'epic_status'}),
+    'pipeline2_pipelines': frozenset({'pipeline_status', 'execution_mode'}),
+    'pipeline2_steps': frozenset({'run'}),
+    'pipeline_steps': frozenset({'run'}),
+    'pipelines': frozenset({'pipeline_status', 'execution_mode'}),
+    'profiles': frozenset({'theme_mode'}),
+    'recurring_tasks': frozenset({'recurrence', 'insert_position'}),
+    'requirements': frozenset({'requirement_status', 'coordination_type',
+                               'ai_model', 'effort'}),
+    # `skill_name` is VARCHAR(64) — WIDER than the sweep, registered by hand.
+    'swarm_completes': frozenset({'status', 'ai_model', 'effort', 'skill_name'}),
+    'swarm_sessions': frozenset({'swarm_status', 'ai_model', 'effort'}),
+    'swarm_starts': frozenset({'ai_model', 'effort'}),
+    'test_cases': frozenset({'test_type'}),
+    'test_results': frozenset({'result_status'}),
+    'test_runs': frozenset({'run_status'}),
+    # VARCHAR(50), also wider than the sweep. One member, `'strava'`.
+    'user_integrations': frozenset({'provider'}),
+}
+
+# The written-down exemption set, and the same call as `UNSCOPED_TABLES` /
+# `UNCHECKED_CREATOR_REFERENCES`: a NOT NULL narrow column left out of the
+# registry above has to be left out ON PURPOSE and in writing, because omission
+# and exemption are indistinguishable in a hand-written list.
+#
+# Unlike those two this one is NOT empty, and cannot be — the candidate rule is
+# structural (narrow + NOT NULL) and real free-text columns match it. Each entry
+# is a column whose value the USER or an IMPORT supplies, where the gateway has
+# no domain to police and refusing a blank would be refusing something the app
+# legitimately writes:
+#
+#   domains.domain_name / areas.area_name / map_views.name
+#       user-typed names. Darwin's "type into the blank row" pattern POSTs a
+#       template whose name field starts empty, and `areas.area_name` holds a
+#       single-space row in production today.
+#   map_runs.activity_name
+#       the activity label as the IMPORT found it (Cyclemeter / Strava / KML).
+#       Darwin does not define this value set — `RouteCard.jsx` seeds its own
+#       state from `run.activity_name || ''` — so it is not a bounded domain.
+#   agents.ai_model
+#       the RESOLVED model id (`opus[1m]` in production), which the schema
+#       comment explicitly marks as NOT the haiku|sonnet|opus|fable family enum.
+#       `agents.effort` IS that family and is registered above.
+FREE_TEXT_NOT_NULL_COLUMNS = {
+    'agents': frozenset({'ai_model'}),
+    'areas': frozenset({'area_name'}),
+    'domains': frozenset({'domain_name'}),
+    'map_runs': frozenset({'activity_name'}),
+    'map_views': frozenset({'name'}),
+}
+
+
+def _is_blank(value):
+    """True when `value` would land in a NOT NULL enum column as no value at all.
+
+    Four shapes, all of which mean the caller named the column and supplied
+    nothing usable:
+
+      ''        the empty string — legal VARCHAR, illegal enum member
+      '   '     whitespace only; no enum value in this schema is whitespace
+      None      JSON null. MySQL answers 1048 on a single-row write, so this is
+                a 500 today; a 400 naming the column is the truthful status for
+                a request that was malformed before it reached the database.
+      'NULL'    the gateway's clear-to-NULL sentinel (`rest_post`/`rest_put`
+                translate it to None a few lines after this check), so it is the
+                same request as the line above wearing the API's own spelling.
+
+    A non-string is left alone. `0` and `False` are not blanks — they are wrong
+    values, which is the domain question this guard deliberately does not ask.
+    """
+    if value is None or value == 'NULL':
+        return True
+    return isinstance(value, str) and value.strip() == ''
+
+
+def check_enum_blanks(table, bodies):
+    """`(status, message)` when a write supplies a NOT NULL enum BLANK, else None.
+
+    Read with `body_column()`, not `body.get()`. MySQL matches a column name
+    case-insensitively, so `{"AI_MODEL": ""}` writes `requirements.ai_model` while
+    an exact-string lookup sees nothing — the req #3125 rule, that anything this
+    gateway both CHECKS and WRITES must be read by the check exactly as the writer
+    writes it. `check_body_keys` runs first on every path that calls this, so the
+    key charset is already a plain identifier and at most one spelling can match.
+
+    An ABSENT key is allowed and that is the whole partial-write contract: on a
+    POST it means "use the column default" (req #3434 gives `requirements.ai_model`
+    and `.effort` one) and on a PUT it means "unchanged". Only a key the caller
+    actually sent is inspected.
+    """
+    columns = ENUM_COLUMNS.get(table)
+    if not columns:
+        return None
+    for body in bodies:
+        if not isinstance(body, dict):
+            return (400, 'BAD REQUEST')
+        for column in sorted(columns):
+            present, value = body_column(body, column)
+            if present and _is_blank(value):
+                # Two different outcomes were being averted, so say which one.
+                # A message that calls `None` "a legal VARCHAR stored silently"
+                # sends whoever reads it in CloudWatch looking for a row that
+                # does not exist — MySQL answers 1048 for that shape.
+                if value is None or value == 'NULL':
+                    because = ("SQL NULL is not writable to a NOT NULL column at "
+                               "all, so this would have been a MySQL 1048 reported "
+                               "as an opaque 500")
+                else:
+                    because = ("the empty string is a legal VARCHAR and would be "
+                               "stored silently under this instance's non-strict "
+                               "sql_mode, matching no branch in any reader")
+                print(f"Auth: {table} write supplying a blank value for the NOT "
+                      f"NULL column {column} ({value!r}) — {because} (req #3432). "
+                      "Omit the column to take its default, or send a real value.")
+                return (400, 'BAD REQUEST')
+    return None
 
 
 def junction_parent_columns(table):

--- a/rest_post.py
+++ b/rest_post.py
@@ -4,7 +4,7 @@ from rest_api_utils import (compose_rest_response, compose_conflict_response,
                             error_detail, integrity_errno, parent_reference_guard)
 from classifier import varDump, pretty_print_sql
 from auth_utils import (CREATOR_FK_TABLES, PROFILE_TABLE, check_body_keys,
-                        force_column)
+                        check_enum_blanks, force_column)
 
 def rest_post(post_method, conn, database, table, body, authenticated_user=None):
 
@@ -22,6 +22,15 @@ def rest_post(post_method, conn, database, table, body, authenticated_user=None)
     # every check saw no reference at all. Held to a plain identifier here so the
     # set of columns checked IS the set of columns written.
     refusal = check_body_keys(table, [body])
+    if refusal is not None:
+        return compose_rest_response(refusal[0], '', refusal[1])
+
+    # req #3432 — a NOT NULL column with a bounded value domain, named by the body
+    # but supplied blank. `''` is a legal VARCHAR, so MySQL stores it silently and
+    # every reader that switches on the enum then matches no branch. Refused
+    # AFTER `check_body_keys`, which is what guarantees the key this reads is the
+    # column that would be written.
+    refusal = check_enum_blanks(table, [body])
     if refusal is not None:
         return compose_rest_response(refusal[0], '', refusal[1])
 
@@ -258,6 +267,13 @@ def _rest_post_bulk(post_method, conn, table, body_list, authenticated_user):
 
     # req #3125 — see the single-row path. Same reason, every item.
     refusal = check_body_keys(table, body_list)
+    if refusal is not None:
+        return compose_rest_response(refusal[0], '', refusal[1])
+
+    # req #3432 — every item, not a sample. The statement below is ONE
+    # multi-value INSERT that lands or rolls back as a unit, so one blank enum
+    # anywhere in the batch has to refuse the whole batch.
+    refusal = check_enum_blanks(table, body_list)
     if refusal is not None:
         return compose_rest_response(refusal[0], '', refusal[1])
 

--- a/rest_put.py
+++ b/rest_put.py
@@ -4,7 +4,8 @@ from rest_api_utils import (compose_rest_response, compose_conflict_response,
                             error_detail, integrity_errno, parent_reference_guard)
 from classifier import varDump, pretty_print_sql
 from auth_utils import (CREATOR_FK_TABLES, PROFILE_TABLE, body_column,
-                        check_body_keys, force_column, junction_scope_clause)
+                        check_body_keys, check_enum_blanks, force_column,
+                        junction_scope_clause)
 
 def rest_put(put_method, conn, database, table, body_list, authenticated_user=None):
 
@@ -19,6 +20,15 @@ def rest_put(put_method, conn, database, table, body_list, authenticated_user=No
     # would check `test_plan_fk` and the statement would apply `TEST_PLAN_FK`.
     # Both are refused here, before anything reads a key.
     refusal = check_body_keys(table, body_list)
+    if refusal is not None:
+        return compose_rest_response(refusal[0], '', refusal[1])
+
+    # req #3432 — a NOT NULL column with a bounded value domain, named by the body
+    # but supplied blank. PUT needs this as much as POST and arguably more: an
+    # UPDATE has no "column default" to fall back on, so a blank here does not
+    # merely create a bad row, it OVERWRITES a good value with one that matches no
+    # branch in any reader. An absent key still means unchanged.
+    refusal = check_enum_blanks(table, body_list)
     if refusal is not None:
         return compose_rest_response(refusal[0], '', refusal[1])
 

--- a/tests/test_unit_enum_blank.py
+++ b/tests/test_unit_enum_blank.py
@@ -1,0 +1,473 @@
+"""A NOT NULL enum column must never be written BLANK through the gateway (req #3432).
+
+No database, no `exports.sh`. Three layers, and each one fails for a different
+reason if the fix is reverted:
+
+  * REGISTRY CONFORMANCE — the candidate columns are re-derived from
+    `DarwinSQL/schema.sql` on every run, so a new enum column fails the build
+    until somebody classifies it. This is the `CREATOR_TABLE_REFERENCES`
+    discipline (req #3125): the audit that filed that requirement counted eleven
+    columns and the DDL said thirty-six, so no list here is hand-counted.
+  * GUARD BEHAVIOUR — what `check_enum_blanks` refuses and, just as important,
+    what it must NOT refuse. An absent key is the partial-write contract; a
+    guard that refused omission would break every POST that relies on a column
+    default and every PUT that names one field.
+  * GATEWAY BOUNDARY — `rest_post` and `rest_put` called for real. The
+    connection they are handed raises if anything asks it for a cursor, so a
+    test that returns 400 has PROVED no SQL ran, and a test that raises has
+    proved the guard let a legitimate write through instead of over-refusing.
+
+WHY THE BLANK IS THE WHOLE OF IT. Measured in production 2026-08-09: 18
+`requirements` rows carry `ai_model=''` and/or `effort=''` — the two NOT NULL
+enum columns in the entire schema that have no column DEFAULT, which is what
+made a caller's OMISSION land as MySQL's implicit empty-string fill under this
+instance's non-strict `sql_mode`. Req #3434 gives them a DEFAULT so omission is
+safe; this file is the other half, and covers the caller that sends the key with
+nothing in it. The allowed VALUES are deliberately not asserted anywhere here —
+see the `ENUM_COLUMNS` comment for why the registry holds no value lists.
+"""
+import os
+import re
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from auth_utils import (ENUM_COLUMNS, FREE_TEXT_NOT_NULL_COLUMNS, _is_blank,
+                        check_enum_blanks)
+from rest_post import rest_post
+from rest_put import rest_put
+
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# schema.sql parsing — the source of truth the registry is checked against
+# ---------------------------------------------------------------------------
+
+# A column no wider than this is a candidate. The bound is structural rather
+# than semantic on purpose: "which columns hold an enum" is exactly the judgment
+# this file exists to stop somebody making silently, so the parse casts a wide
+# net and the registries record the call. Every enum column in the schema today
+# is VARCHAR(32) or narrower (`branches.branch_type` is the widest).
+NARROW = 32
+
+_CREATE = re.compile(r'\s*CREATE TABLE (?:IF NOT EXISTS )?`?(\w+)`?', re.I)
+_END = re.compile(r'\s*\)\s*;')
+_NOT_A_COLUMN = re.compile(
+    r'(PRIMARY|UNIQUE|CONSTRAINT|FOREIGN|INDEX|KEY|CHECK)\b', re.I)
+_COLUMN = re.compile(
+    r'`?(\w+)`?\s+(ENUM\s*\([^)]*\)|VARCHAR\s*\(\s*(\d+)\s*\)'
+    r'|CHAR\s*\(\s*(\d+)\s*\))(.*)$', re.I)
+
+
+def _schema_path():
+    """DarwinSQL/schema.sql as a sibling of Lambda-Rest, or None."""
+    here = os.path.dirname(os.path.abspath(__file__))
+    candidate = os.path.join(here, '..', '..', 'DarwinSQL', 'schema.sql')
+    return candidate if os.path.exists(candidate) else None
+
+
+def _closed(text):
+    """True when `text` has no unbalanced `(`.
+
+    A definition ends at a TOP-LEVEL comma, never one inside a parenthesis. A
+    wrapped `ENUM('draft','active',` / `'paused')` value list ends its first line
+    on a comma, and treating that as the end of the statement drops the column
+    from the parse ENTIRELY — silently, which would make
+    `test_every_candidate_column_is_classified` vacuous for exactly the shape a
+    five-value enum is most naturally written in. Found by mutation-testing this
+    parser against an injected column, not by reading it.
+    """
+    return text.count('(') == text.count(')')
+
+
+def _parse_columns(path):
+    """`(candidates, all_text_columns)` from the DDL, each `{table: {column…}}`.
+
+    `candidates` is the structural sweep — NOT NULL, and either a real
+    `ENUM(...)` or a CHAR/VARCHAR no wider than `NARROW`. That is what every
+    column must be CLASSIFIED against.
+
+    `all_text_columns` is every NOT NULL CHAR/VARCHAR/ENUM of ANY width, and it
+    exists because the sweep is a filter rather than a proof: a bounded domain
+    declared wider (`swarm_completes.skill_name` VARCHAR(64)) is registered by
+    hand, so "does this registered column exist?" has to be asked against the
+    wider set or the hand registration would read as a typo.
+
+    Comments are stripped FIRST. `pipelines.execution_mode` declares its type on
+    one line and `NOT NULL DEFAULT 'parallel'` on the next with a `--` comment
+    between them, so a line-at-a-time parse that respected comments would read
+    the column as nullable and drop the schema's only two real `ENUM(...)`
+    columns without saying so.
+    """
+    candidates, all_text = {}, {}
+    table = None
+    buffer = ''
+    for raw in open(path).read().splitlines():
+        line = raw.split('--', 1)[0].rstrip()
+        match = _CREATE.match(line)
+        if match:
+            table, buffer = match.group(1), ''
+            continue
+        if table is None:
+            continue
+        if _END.match(line) and _closed(buffer):
+            table, buffer = None, ''
+            continue
+        buffer = (buffer + ' ' + line.strip()).strip()
+        if not buffer:
+            continue
+        # Complete at a top-level trailing comma, or as soon as the definition
+        # carries its own nullness — the latter is what lets the two-line ENUM
+        # above resolve, the `_closed` guard is what stops a wrapped value list
+        # from resolving too early.
+        if not _closed(buffer):
+            continue
+        if not (buffer.endswith(',') or re.search(r'NULL\b', buffer, re.I)):
+            continue
+        statement, buffer = buffer.rstrip(',').strip(), ''
+        if _NOT_A_COLUMN.match(statement):
+            continue
+        column = _COLUMN.match(statement)
+        if not column:
+            continue
+        name, column_type, varchar_width, char_width, tail = column.groups()
+        if 'NOT NULL' not in tail.upper():
+            continue
+        if re.search(r'PRIMARY KEY|AUTO_INCREMENT', tail, re.I):
+            continue
+        all_text.setdefault(table, set()).add(name)
+        width = int(varchar_width or char_width or 0)
+        if not column_type.upper().startswith('ENUM') and width > NARROW:
+            continue
+        candidates.setdefault(table, set()).add(name)
+    return candidates, all_text
+
+
+@pytest.fixture(scope='module')
+def parsed():
+    path = _schema_path()
+    if path is None:
+        pytest.skip('DarwinSQL/schema.sql not present as a sibling repo')
+    return _parse_columns(path)
+
+
+@pytest.fixture(scope='module')
+def candidates(parsed):
+    return parsed[0]
+
+
+@pytest.fixture(scope='module')
+def all_text_columns(parsed):
+    return parsed[1]
+
+
+def _pairs(registry):
+    return {(table, column)
+            for table, columns in registry.items() for column in columns}
+
+
+# ---------------------------------------------------------------------------
+# Registry conformance — the test that stops the next unregistered enum
+# ---------------------------------------------------------------------------
+
+def test_schema_parse_found_the_columns(candidates, all_text_columns):
+    """Guard the guard: an empty parse would make every test below vacuous."""
+    assert len(_pairs(candidates)) > 30, (
+        f'parsed only {len(_pairs(candidates))} candidate columns from schema.sql')
+    # One of each shape the parser has to handle: a plain narrow VARCHAR, and
+    # the two-line real ENUM whose NOT NULL sits under a comment.
+    assert 'ai_model' in candidates['requirements']
+    assert 'effort' in candidates['requirements']
+    assert 'execution_mode' in candidates['pipelines']
+    # The wider set is a superset and reaches past NARROW.
+    assert _pairs(candidates) <= _pairs(all_text_columns)
+    assert 'skill_name' in all_text_columns['swarm_completes']
+    assert 'skill_name' not in candidates.get('swarm_completes', set())
+
+
+def test_a_wrapped_enum_value_list_does_not_end_the_definition_early():
+    """The `_closed` guard, tested directly rather than trusted.
+
+    A five-value `ENUM(...)` wrapped across two lines ends its first line on a
+    comma. Before this guard the parser took that comma as the end of the
+    statement, matched nothing, and dropped the column from `candidates`
+    ENTIRELY — so the classification test would have passed while the gateway
+    silently accepted `''` on it.
+    """
+    import tempfile
+    ddl = (
+        "CREATE TABLE IF NOT EXISTS zz_probe (\n"
+        "    id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,\n"
+        "    wrapped ENUM('draft', 'active',\n"
+        "                 'paused', 'completed')\n"
+        "                 NOT NULL DEFAULT 'draft',\n"
+        "    flat VARCHAR(16) NOT NULL DEFAULT 'x'\n"
+        ");\n")
+    with tempfile.NamedTemporaryFile('w', suffix='.sql', delete=False) as handle:
+        handle.write(ddl)
+        path = handle.name
+    try:
+        candidates, _ = _parse_columns(path)
+    finally:
+        os.unlink(path)
+    assert candidates.get('zz_probe') == {'wrapped', 'flat'}
+
+
+def test_every_candidate_column_is_classified(candidates):
+    """THE invariant: no NOT NULL enum-shaped column is silently unguarded.
+
+    Add `swarm_status_v2 VARCHAR(16) NOT NULL DEFAULT 'x'` to schema.sql and this
+    fails until it is put in `ENUM_COLUMNS` or written down as free text — which
+    is the whole point, because the alternative is a column that quietly accepts
+    `''` for however long it takes somebody to notice a reader matching no
+    branch.
+    """
+    classified = _pairs(ENUM_COLUMNS) | _pairs(FREE_TEXT_NOT_NULL_COLUMNS)
+    unclassified = sorted(_pairs(candidates) - classified)
+    assert not unclassified, (
+        'NOT NULL enum-shaped columns in schema.sql that are in neither '
+        f'ENUM_COLUMNS nor FREE_TEXT_NOT_NULL_COLUMNS: {unclassified}')
+
+
+def test_no_column_is_in_both_registries():
+    """A column is either policed or exempt. Both is a contradiction, and the
+    guard would silently police it — the registry that is READ would win over
+    the one that documents the decision."""
+    overlap = sorted(_pairs(ENUM_COLUMNS) & _pairs(FREE_TEXT_NOT_NULL_COLUMNS))
+    assert not overlap, f'registered as both enum and free text: {overlap}'
+
+
+def test_every_registered_column_exists_in_the_schema(all_text_columns):
+    """A registered column the DDL does not have is dead weight that reads as
+    coverage. Catches a rename and a typo alike.
+
+    Checked against the WIDER set, not `candidates`: a bounded domain declared
+    wider than `NARROW` is registered by hand and is legitimately outside the
+    sweep, so asking this question against the sweep would reject the two real
+    ones as typos."""
+    unknown = sorted(
+        (_pairs(ENUM_COLUMNS) | _pairs(FREE_TEXT_NOT_NULL_COLUMNS))
+        - _pairs(all_text_columns))
+    assert not unknown, (
+        f'registered but not a NOT NULL text column in schema.sql: {unknown}')
+
+
+def test_the_hand_registered_wide_columns_are_covered(candidates):
+    """The sweep is a filter, not a proof — these two prove it and are the
+    reason the distinction is written down rather than assumed away.
+
+    Both accepted `''` silently until they were listed, and neither is narrow
+    enough for the structural rule to have found them."""
+    assert 'skill_name' in ENUM_COLUMNS['swarm_completes']
+    assert 'provider' in ENUM_COLUMNS['user_integrations']
+    assert 'skill_name' not in candidates.get('swarm_completes', set())
+    assert 'provider' not in candidates.get('user_integrations', set())
+    assert check_enum_blanks('swarm_completes', [{'skill_name': ''}]) == (400, 'BAD REQUEST')
+    assert check_enum_blanks('user_integrations', [{'provider': ''}]) == (400, 'BAD REQUEST')
+
+
+def test_the_four_columns_this_requirement_was_filed_for_are_registered():
+    """Named explicitly so a refactor cannot drop them and stay green: these are
+    the columns `/swarm-start` reads straight into the launch command."""
+    assert {'ai_model', 'effort'} <= ENUM_COLUMNS['requirements']
+    assert {'requirement_status', 'coordination_type'} <= ENUM_COLUMNS['requirements']
+
+
+# ---------------------------------------------------------------------------
+# _is_blank — what counts as "named the column and supplied nothing"
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize('value', ['', ' ', '   ', '\t', '\n', ' \t\n ',
+                                   None, 'NULL'])
+def test_is_blank_catches_every_shape_of_no_value(value):
+    assert _is_blank(value) is True
+
+
+@pytest.mark.parametrize('value', ['opus', 'high', 'a', ' opus', 'opus ',
+                                   'null', 'Null', 0, 1, False, True, 3.0])
+def test_is_blank_leaves_real_values_alone(value):
+    """`'null'` lowercase is NOT the sentinel — the gateway's spelling is exactly
+    `'NULL'`, and quietly widening that would refuse a legitimate value on some
+    future column whose domain contains the word.
+
+    `0` and `False` are wrong values, not absent ones. Refusing them would be the
+    DOMAIN check this guard deliberately does not make.
+    """
+    assert _is_blank(value) is False
+
+
+# ---------------------------------------------------------------------------
+# check_enum_blanks — the guard itself
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize('blank', ['', '   ', None, 'NULL'])
+def test_refuses_a_blank_on_a_registered_column(blank):
+    assert check_enum_blanks('requirements', [{'ai_model': blank}]) == (400, 'BAD REQUEST')
+
+
+def test_refuses_a_blank_however_the_key_is_cased():
+    """MySQL matches a column name case-insensitively, so `{"AI_MODEL": ""}`
+    writes `requirements.ai_model`. An exact-string lookup would see no column
+    named at all and wave it through — the req #3125 rule, which defeated two
+    other registries before it was written down."""
+    for key in ('AI_MODEL', 'Ai_Model', 'aI_mOdEl'):
+        assert check_enum_blanks('requirements', [{key: ''}]) == (400, 'BAD REQUEST')
+
+
+def test_allows_a_real_value():
+    assert check_enum_blanks('requirements', [{'ai_model': 'opus',
+                                               'effort': 'high'}]) is None
+
+
+def test_allows_an_absent_column():
+    """The partial-write contract. On a POST an absent key takes the column
+    default (req #3434 gives these two one); on a PUT it means unchanged. A guard
+    that required the column would break both."""
+    assert check_enum_blanks('requirements', [{'title': 'x'}]) is None
+    assert check_enum_blanks('requirements', [{'id': 1, 'title': 'x'}]) is None
+
+
+def test_ignores_an_unregistered_column_on_a_registered_table():
+    """`requirements.title` is NOT NULL too, and Darwin's blank-row pattern POSTs
+    it empty. Policing it here would refuse the app's own create flow."""
+    assert check_enum_blanks('requirements', [{'title': ''}]) is None
+    assert check_enum_blanks('requirements', [{'description': ''}]) is None
+
+
+def test_ignores_an_unregistered_table():
+    assert check_enum_blanks('tasks', [{'task_name': ''}]) is None
+    assert check_enum_blanks('nonexistent_table', [{'anything': ''}]) is None
+
+
+def test_exempt_free_text_columns_are_not_policed():
+    """`areas.area_name` holds a single-space row in production and Darwin's
+    template row POSTs it empty; `map_runs.activity_name` is whatever the
+    Cyclemeter/Strava import found. Refusing these would be a regression, which
+    is why they are written down rather than merely omitted."""
+    assert check_enum_blanks('areas', [{'area_name': ''}]) is None
+    assert check_enum_blanks('map_runs', [{'activity_name': ''}]) is None
+    assert check_enum_blanks('agents', [{'ai_model': ''}]) is None
+    # …and the enum column on the same table still is.
+    assert check_enum_blanks('areas', [{'sort_mode': ''}]) == (400, 'BAD REQUEST')
+    assert check_enum_blanks('agents', [{'effort': ''}]) == (400, 'BAD REQUEST')
+
+
+def test_one_blank_anywhere_refuses_the_whole_batch():
+    """A bulk POST is one multi-value INSERT that lands or rolls back as a unit,
+    so a per-item verdict is not available to the caller anyway."""
+    batch = [{'ai_model': 'opus'}, {'ai_model': 'sonnet'}, {'ai_model': ''}]
+    assert check_enum_blanks('requirements', batch) == (400, 'BAD REQUEST')
+
+
+def test_a_non_dict_body_is_refused():
+    assert check_enum_blanks('requirements', ['not a dict']) == (400, 'BAD REQUEST')
+
+
+# ---------------------------------------------------------------------------
+# Gateway boundary — rest_post / rest_put for real
+# ---------------------------------------------------------------------------
+
+class CursorRequested(Exception):
+    """Raised by the stub connection the instant anything opens a cursor."""
+
+
+class NoSqlConnection:
+    """A connection that cannot run SQL, so reaching the database is visible.
+
+    A refusal must return 400 having never asked for a cursor; a legitimate write
+    must reach one. Asserting BOTH is what makes these tests fail on a reverted
+    wiring (no refusal) and on an over-broad guard (no cursor) alike, instead of
+    passing vacuously.
+    """
+
+    def cursor(self):
+        raise CursorRequested()
+
+    def rollback(self):
+        raise CursorRequested()
+
+
+USER = '37df7531-0000-0000-0000-000000000000'
+
+
+@pytest.mark.parametrize('blank', ['', '   ', None, 'NULL'])
+def test_rest_post_refuses_a_blank_enum_without_touching_the_database(blank):
+    response = rest_post('POST', NoSqlConnection(), 'darwin_dev', 'requirements',
+                         {'title': 'x', 'category_fk': 1, 'ai_model': blank},
+                         authenticated_user=USER)
+    assert response['statusCode'] == 400
+
+
+def test_rest_post_bulk_refuses_a_blank_enum_without_touching_the_database():
+    response = rest_post('POST', NoSqlConnection(), 'darwin_dev', 'requirements',
+                         [{'title': 'a', 'effort': 'high'},
+                          {'title': 'b', 'effort': ''}],
+                         authenticated_user=USER)
+    assert response['statusCode'] == 400
+
+
+@pytest.mark.parametrize('blank', ['', '   ', None, 'NULL'])
+def test_rest_put_refuses_a_blank_enum_without_touching_the_database(blank):
+    response = rest_put('PUT', NoSqlConnection(), 'darwin_dev', 'requirements',
+                        [{'id': 1, 'effort': blank}], authenticated_user=USER)
+    assert response['statusCode'] == 400
+
+
+def test_rest_put_bulk_refuses_a_blank_enum_without_touching_the_database():
+    response = rest_put('PUT', NoSqlConnection(), 'darwin_dev', 'requirements',
+                        [{'id': 1, 'effort': 'high'},
+                         {'id': 2, 'effort': ''}], authenticated_user=USER)
+    assert response['statusCode'] == 400
+
+
+@pytest.mark.parametrize('key', ['AI_MODEL', 'Ai_Model', 'aI_mOdEl'])
+def test_rest_post_refuses_a_blank_however_the_key_is_cased(key):
+    """The same case-insensitivity as the unit test above, but through the REAL
+    entry point — because what makes it work is an ORDERING (`check_body_keys`
+    settles the key charset before the guard reads it), and an ordering can only
+    regress where the order actually is."""
+    response = rest_post('POST', NoSqlConnection(), 'darwin_dev', 'requirements',
+                         {'title': 'x', key: ''}, authenticated_user=USER)
+    assert response['statusCode'] == 400
+
+
+@pytest.mark.parametrize('key', ['EFFORT', 'Effort'])
+def test_rest_put_refuses_a_blank_however_the_key_is_cased(key):
+    response = rest_put('PUT', NoSqlConnection(), 'darwin_dev', 'requirements',
+                        [{'id': 1, key: '   '}], authenticated_user=USER)
+    assert response['statusCode'] == 400
+
+
+def test_rest_post_lets_a_real_value_through_to_the_database():
+    """The over-refusal half. Reaching the cursor is the pass condition — what
+    the INSERT would then do needs a database and is not this file's question."""
+    with pytest.raises(CursorRequested):
+        rest_post('POST', NoSqlConnection(), 'darwin_dev', 'requirements',
+                  {'title': 'x', 'ai_model': 'opus', 'effort': 'high'},
+                  authenticated_user=USER)
+
+
+def test_rest_put_lets_a_real_value_through_to_the_database():
+    with pytest.raises(CursorRequested):
+        rest_put('PUT', NoSqlConnection(), 'darwin_dev', 'requirements',
+                 [{'id': 1, 'ai_model': 'opus'}], authenticated_user=USER)
+
+
+def test_rest_post_lets_an_omitted_enum_through_to_the_database():
+    """Omission is req #3434's half and must stay untouched here — a guard that
+    required the column would break every caller relying on a column default."""
+    with pytest.raises(CursorRequested):
+        rest_post('POST', NoSqlConnection(), 'darwin_dev', 'requirements',
+                  {'title': 'x', 'category_fk': 1}, authenticated_user=USER)
+
+
+def test_rest_post_still_lets_a_blank_free_text_column_through():
+    """Darwin's "type into the blank row" pattern POSTs template objects whose
+    name field is empty. This is the regression the exemption set exists for."""
+    with pytest.raises(CursorRequested):
+        rest_post('POST', NoSqlConnection(), 'darwin_dev', 'domains',
+                  {'domain_name': ''}, authenticated_user=USER)


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/AWS-Lambda-REST-API into feature/3432-empty-string-stored-in-ai-model-1
- wip(Lambda-Rest): 2026-08-09T10:03:02Z
- chore: init swarm session feature/3432-empty-string-stored-in-ai-model-1

## Files changed
```
 CLAUDE.md                     |  67 +++++-
 auth_utils.py                 | 189 +++++++++++++++++
 rest_post.py                  |  18 +-
 rest_put.py                   |  12 +-
 tests/test_unit_enum_blank.py | 473 ++++++++++++++++++++++++++++++++++++++++++
 5 files changed, 756 insertions(+), 3 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)