### PR TITLE
Pipeline 2.0 - one derivation behind a composing Lambda-Rest route (remediation B)

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -13,6 +13,19 @@ from rest_post import rest_post
 from rest_delete import rest_delete
 from auth_utils import (get_authenticated_user, CREATOR_FK_TABLES,
                         JUNCTION_OWNERSHIP, PROFILE_TABLE)
+import pipeline2_compose
+
+# req #3367 — the ONE non-generic route (remediation B, composing form).
+# `pipeline2_compose` / `pipeline2_compose_epic` are not real tables; they are
+# reserved route names dispatched to `pipeline2_compose.py` BEFORE the generic
+# `{database}/{table}` gateway ever sees them. GET only, `id` as a query
+# string parameter — same grammar as every other single-row lookup
+# (`GET /darwin/pipeline2_compose?id=5`), so the existing darwin-mcp REST
+# client needs no new URL-building code, only a new response-shape method.
+PIPELINE2_COMPOSE_ROUTES = {
+    'pipeline2_compose': pipeline2_compose.compose_pipeline2,
+    'pipeline2_compose_epic': pipeline2_compose.compose_pipeline2_epic,
+}
 
 
 #
@@ -29,6 +42,21 @@ db_names = set(os.environ['db_name'].split(','))
 print('RestApi-MySql-Lambda init code executing.')
 
 SAFE_NAME_RE = re.compile(r'^[a-zA-Z_][a-zA-Z0-9_]*$')
+
+# The same integer grammar auth_utils._reference_value enforces for a body-
+# supplied id — MySQL's, not Python's (req #3122's canonicalization rule).
+# QSP values arrive as strings, so this is the ONE place that grammar needs
+# restating for a query-string id rather than a body field.
+_ID_QSP_RE = re.compile(r'^[+-]?[0-9]+$')
+
+
+def _parse_id_qsp(event):
+    """The `id` query-string parameter as an int, or None if absent/invalid."""
+    qsp = event.get('queryStringParameters') or {}
+    raw = qsp.get('id')
+    if raw is None or not _ID_QSP_RE.match(raw.strip()):
+        return None
+    return int(raw.strip())
 
 def parse_path(path):
 
@@ -117,6 +145,12 @@ def rest_api_from_table(event, db_info):
     # Extract authenticated user from Cognito authorizer claims
     authenticated_user = get_authenticated_user(event)
 
+    # req #3367 — the composing route, dispatched BEFORE the generic gateway
+    # (these are not real tables, so DESC/CRUD below would only ever fail).
+    if table in PIPELINE2_COMPOSE_ROUTES:
+        return _rest_pipeline2_compose(table, conn, event, http_method,
+                                       authenticated_user)
+
     # Block unauthenticated access to user-scoped tables.
     #
     # JUNCTION_OWNERSHIP tables join in (req #3122). Their scoping is derived
@@ -160,3 +194,37 @@ def rest_api_from_table(event, db_info):
 
         # DELETE Method
         return rest_delete(delete_method, conn, database, table, body, authenticated_user)
+
+
+def _rest_pipeline2_compose(table, conn, event, http_method, authenticated_user):
+    """req #3367 — GET-only, `id` as a query-string parameter, same shape as
+    every other single-row lookup. Not a real table, so PUT/POST/DELETE and a
+    missing/malformed `id` are refused here rather than reaching pymysql."""
+    if http_method != get_method:
+        return compose_rest_response(
+            400, '', f"{table} is a read-only composed route; {http_method} not allowed")
+
+    # Same gate the generic CREATOR_FK_TABLES check gives every other
+    # user-scoped table — this route names none of the real table names that
+    # check matches on, so it needs its own.
+    if authenticated_user is None:
+        print(f'Auth: unauthenticated request to composed route {table}')
+        return compose_rest_response(403, '', 'FORBIDDEN')
+
+    row_id = _parse_id_qsp(event)
+    if row_id is None:
+        return compose_rest_response(400, '', f"{table}: a valid integer 'id' query "
+                                     "parameter is required")
+
+    try:
+        composed = PIPELINE2_COMPOSE_ROUTES[table](conn, row_id, authenticated_user)
+    except ValueError as e:
+        # A data-integrity issue (epic names a pipeline_fk that does not
+        # resolve for this creator) — real but not the caller's fault to fix
+        # by retrying, so 500 rather than 400/404.
+        print(f"{table} data integrity error: {e}")
+        return compose_rest_response(500, '', str(e))
+
+    if composed is None:
+        return compose_rest_response(404, '', 'NOT FOUND')
+    return compose_rest_response(200, composed)

--- a/pipeline2_compose.py
+++ b/pipeline2_compose.py
@@ -1,0 +1,379 @@
+"""Pipeline 2.0 — the composing route (req #3367, remediation B, composing
+form: `memory/pipeline-2-orchestration-algorithm.md` § 8).
+
+The ONE non-generic Lambda-Rest route over the `pipeline2_*` tables. Where the
+generic gateway (`rest_get_table.py`) answers one table per round trip,
+this module answers the WHOLE composed plan read in one Lambda invocation —
+several SQL SELECTs over an already-open connection, never a second Lambda
+call — because "no JOIN" is a property of the generic table gateway, not of
+Lambda-Rest itself.
+
+Mirrors `darwin-mcp/services/pipelines2.py`'s (pre-#3367) `get_pipeline2_composed`
+/ `get_pipeline2_epic_composed` read shape and tier-skip logic EXACTLY, so the
+payload this emits is what those functions used to build by hand over six
+gateway round trips — byte-compatible, so a consumer cannot tell which
+produced it. That module is now a ONE-CALL passthrough to this route.
+
+    {pipeline, epics[], steps[], step_requirements[], step_deps[],
+     requirements[], derived{}}
+
+`pipeline2_derive.derive_plan2` (moved here from darwin-mcp by this same
+requirement — see that module's docstring) computes `derived`. A deriver
+exception must never take the real rows down with it, so it degrades to a
+WITHHELD stub exactly as darwin-mcp's `_derive` guard did.
+
+Scoping mirrors what the generic gateway already does for every read of a
+`CREATOR_FK_TABLES` table (`rest_get_table.py`): every `pipeline2_pipelines` /
+`pipeline2_epics` / `pipeline2_steps` / `requirements` SELECT carries
+`creator_fk = %s` explicitly, not merely inherited through containment — the
+same defense-in-depth the generic gateway gave for free, replicated by hand
+because this route bypasses it. `pipeline2_step_requirements` and
+`pipeline2_step_deps` carry no `creator_fk` (JUNCTION_OWNERSHIP, req #3122) —
+scoped by narrowing to the already-scoped `step_fk` ids fetched above them,
+exactly as the daemon's own composed read did.
+"""
+
+import json
+from datetime import date, datetime
+from decimal import Decimal
+
+import pymysql
+
+import pipeline2_derive
+
+# ---------------------------------------------------------------------------
+# The budget ladder (req #3345 deliverable 4 / #3367 deliverable 3) — ported
+# from darwin-mcp/services/common.py. This route is now THE PRODUCER of the
+# composed payload, so the same three-regime ladder that used to run in the
+# daemon (`server._bounded_plan2`) has to run here instead: the payload this
+# emits is subject to the identical API Gateway / Lambda response cap the
+# daemon's own outbound calls were always subject to (req #3078) — moving the
+# compose step into Lambda does not change that ceiling, it just moves who
+# has to respect it.
+# ---------------------------------------------------------------------------
+
+PAYLOAD_BUDGET_BYTES = 3_000_000
+TRUNCATION_KEY = '_truncated'
+
+WITHHELD_DERIVATION_FAILED = 'derivation_failed'
+WITHHELD_BUDGET_DERIVED_ONLY = 'budget_derived_only'
+WITHHELD_BUDGET_ROWS_TRUNCATED = 'budget_rows_truncated'
+
+
+def _json_safe(value):
+    """Recursively convert DB-native values (datetime, Decimal) to the exact
+    shape darwin-mcp's `json_default` used to serialize them as, so a
+    passthrough consumer forwards these bytes unchanged (req #3367's own
+    byte-compatibility acceptance criterion)."""
+    if isinstance(value, dict):
+        return {k: _json_safe(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_json_safe(v) for v in value]
+    if isinstance(value, (datetime, date)):
+        return value.isoformat()
+    if isinstance(value, Decimal):
+        return float(value)
+    return value
+
+
+def payload_bytes(data):
+    return len(json.dumps(data))
+
+
+def truncate_to_budget(rows, *, resource, budget=PAYLOAD_BUDGET_BYTES, hint=None):
+    """Byte-identical algorithm to `services.common.truncate_to_budget` — see
+    that function's docstring for the reasoning. `rows` must already be
+    JSON-safe (this module always converts before calling it)."""
+    if not isinstance(rows, list):
+        raise TypeError(f"truncate_to_budget expects a list, got {type(rows)}")
+
+    total = len(rows)
+    sizes = [payload_bytes(row) for row in rows]
+    prefix = [0]
+    for size in sizes:
+        prefix.append(prefix[-1] + size)
+    if 2 + prefix[total] + 2 * max(0, total - 1) <= budget:
+        return rows
+
+    def build(kept):
+        return {TRUNCATION_KEY: {
+            'resource': resource,
+            'returned': kept,
+            'total': total,
+            'omitted': total - kept,
+            'budget_bytes': budget,
+            'reason': f"payload exceeded the {budget:,}-byte MCP list-read budget "
+                      f"(req #3078); the first {kept} of {total} rows are returned "
+                      "in this resource's own order",
+            'hint': hint or "narrow the read with a filtered resource, or fetch a "
+                            "single row by id for full detail",
+        }}
+
+    def payload_size(kept):
+        return 2 + prefix[kept] + 2 * kept + payload_bytes(build(kept))
+
+    allowance = budget - max(payload_bytes(build(0)),
+                             payload_bytes(build(total))) - 2
+    used, kept = 2, 0
+    for size in sizes:
+        step = size + (2 if kept else 0)
+        if used + step > allowance:
+            break
+        used += step
+        kept += 1
+
+    while kept > 0 and payload_size(kept) > budget:
+        kept -= 1
+
+    return rows[:kept] + [build(kept)]
+
+
+def withheld(reason_code, *, rows_complete, message):
+    return {
+        'withheld': True,
+        'withheld_reason': reason_code,
+        'rows_complete': rows_complete,
+        'reason': message,
+    }
+
+
+def _derive(model, *, epic_scoped=False):
+    try:
+        return pipeline2_derive.derive_plan2(model, epic_scoped=epic_scoped)
+    except Exception as e:                                 # noqa: BLE001
+        print(f"pipeline2_derive.derive_plan2 failed: {e}")
+        return withheld(
+            WITHHELD_DERIVATION_FAILED, rows_complete=True,
+            message=(f"the 2.0 derivation raised {e!r}. The rows above are "
+                     "intact and complete; only the derived answers are "
+                     "absent. Do not sequence or launch from this response."))
+
+
+def _bounded(uri, composed, *, epic_scoped=False):
+    """The THREE-REGIME budget ladder — byte-identical logic to darwin-mcp's
+    (pre-#3367) `server._bounded_plan2`. See that function's (moved) docstring
+    reasoning in the git history; restated briefly here:
+
+    Regime A — whole payload fits, `derived` included. Ship it.
+    Regime B — does not fit; withholding `derived` alone is enough. Every row
+        survives; `derived` becomes `budget_derived_only`, `rows_complete=True`.
+    Regime C — does not fit even without `derived`. `steps` is truncated
+        against the allowance regime B's absence actually buys, `step_requirements`
+        / `step_deps` are pruned to the surviving step ids, `_truncated` is
+        hoisted to the top level, and `derived` becomes `budget_rows_truncated`,
+        `rows_complete=False` — a hard stop.
+    """
+    if not composed.get('steps'):
+        return composed
+
+    escape_hatch = (
+        "" if epic_scoped else
+        " Read the epic-scoped route for a smaller, complete slice of one "
+        "epic if you need `derived` for it.")
+    count_field = "`epics[0].step_count`" if epic_scoped else "`pipeline.step_count`"
+
+    if payload_bytes(composed) <= PAYLOAD_BUDGET_BYTES:
+        return composed
+
+    with_stub = dict(composed)
+    with_stub['derived'] = withheld(
+        WITHHELD_BUDGET_DERIVED_ONLY, rows_complete=True,
+        message=(
+            f"the payload exceeded the {PAYLOAD_BUDGET_BYTES:,}-byte MCP budget "
+            "(req #3078) with `derived` included. Every row above is present "
+            f"and complete — only the convenience block was withheld to fit."
+            f"{escape_hatch}"))
+    if payload_bytes(with_stub) <= PAYLOAD_BUDGET_BYTES:
+        return with_stub
+
+    hint = (f"a step's `notes` is uncapped TEXT; trim the evidence prose."
+            f"{escape_hatch} {count_field} still reports the true total for "
+            "what was requested.")
+
+    def marker_of(rows):
+        return next((row[TRUNCATION_KEY] for row in rows
+                     if TRUNCATION_KEY in row), None)
+
+    # Budget `remaining` against the REGIME-C derived block — the one that
+    # actually ships below — never against regime B's. The two messages are
+    # different lengths and there is no reason they would stay in a
+    # particular order relative to each other; measuring against whichever
+    # one is NOT shipped is exactly the "a few bytes apart" approximation
+    # that flips silently the next time either message's wording changes.
+    regime_c_derived = withheld(
+        WITHHELD_BUDGET_ROWS_TRUNCATED, rows_complete=False,
+        message=(
+            f"the payload exceeded the {PAYLOAD_BUDGET_BYTES:,}-byte MCP budget "
+            "(req #3078) even with `derived` withheld, so `steps` was "
+            "truncated. The dependency graph in this payload is INCOMPLETE — "
+            f"read `_truncated` and {count_field} for the shortfall, and do "
+            "not sequence or launch from this response."))
+    others = {k: v for k, v in with_stub.items() if k != 'steps'}
+    others['derived'] = regime_c_derived
+    remaining = PAYLOAD_BUDGET_BYTES - payload_bytes(others)
+
+    bounded = truncate_to_budget(composed['steps'], resource=uri,
+                                 budget=max(remaining, 0), hint=hint)
+    reserve = payload_bytes({TRUNCATION_KEY: marker_of(bounded)}) + 2
+    bounded = truncate_to_budget(composed['steps'], resource=uri,
+                                 budget=max(remaining - reserve, 0), hint=hint)
+
+    kept = {step['id'] for step in bounded if TRUNCATION_KEY not in step}
+    out = dict(with_stub)
+    out['steps'] = bounded
+    out[TRUNCATION_KEY] = marker_of(bounded)
+    out['step_requirements'] = [
+        row for row in composed['step_requirements'] if row['step_fk'] in kept]
+    out['step_deps'] = [
+        row for row in composed['step_deps']
+        if row['step_fk'] in kept and row.get('dep_step_fk') in kept]
+    out['derived'] = regime_c_derived
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Column projections — byte-identical to darwin-mcp's (pre-#3367) `pipelines2.py`
+# ---------------------------------------------------------------------------
+
+_PIPELINE_COLUMNS = ('id', 'title', 'description', 'pipeline_status',
+                     'execution_mode', 'machine_fk', 'creator_fk',
+                     'started_at', 'completed_at', 'create_ts', 'update_ts')
+_EPIC_COLUMNS = ('id', 'pipeline_fk', 'title', 'description', 'epic_status',
+                 'sort_order', 'category_fk', 'closed')
+_STEP_COLUMNS = ('id', 'epic_fk', 'title', 'run', 'not_before', 'notes',
+                 'completed_at', 'creator_fk', 'create_ts', 'update_ts')
+_LINK_COLUMNS = ('step_fk', 'requirement_fk')
+_DEP_COLUMNS = ('id', 'step_fk', 'dep_step_fk')
+_REQUIREMENT_COLUMNS = ('id', 'title', 'requirement_status', 'coordination_type',
+                        'ai_model', 'effort', 'machine_fk', 'tracking')
+
+
+def _select(cursor, columns, table, where, params, order_by=None):
+    cols = ', '.join(columns)
+    sql = f"SELECT {cols} FROM {table} WHERE {where}"
+    if order_by:
+        sql += f" ORDER BY {order_by}"
+    cursor.execute(sql, params)
+    return [_json_safe(row) for row in cursor.fetchall()]
+
+
+def _in_clause(n):
+    return '(' + ','.join(['%s'] * n) + ')'
+
+
+# ---------------------------------------------------------------------------
+# The two composed reads
+# ---------------------------------------------------------------------------
+
+def compose_pipeline2(conn, pipeline_id, authenticated_user):
+    """THE whole-plan composed render. Returns None when not found (or not
+    owned by `authenticated_user`) — the caller answers 404."""
+    with conn.cursor(pymysql.cursors.DictCursor) as cursor:
+        pipelines = _select(cursor, _PIPELINE_COLUMNS, 'pipeline2_pipelines',
+                            'id = %s AND creator_fk = %s',
+                            (pipeline_id, authenticated_user))               # read 1
+        if not pipelines:
+            return None
+        pipeline = pipelines[0]
+
+        epics = _select(cursor, _EPIC_COLUMNS, 'pipeline2_epics',
+                        'pipeline_fk = %s AND creator_fk = %s',
+                        (pipeline_id, authenticated_user), order_by='id ASC')  # read 2
+
+        steps = []
+        if epics:
+            epic_ids = sorted(e['id'] for e in epics)
+            steps = _select(
+                cursor, _STEP_COLUMNS, 'pipeline2_steps',
+                f'epic_fk IN {_in_clause(len(epic_ids))} AND creator_fk = %s',
+                tuple(epic_ids) + (authenticated_user,), order_by='id ASC')    # read 3
+        pipeline['step_count'] = len(steps)
+
+        links, deps = [], []
+        if steps:
+            step_ids = sorted(s['id'] for s in steps)
+            in_clause = _in_clause(len(step_ids))
+            links = _select(cursor, _LINK_COLUMNS, 'pipeline2_step_requirements',
+                            f'step_fk IN {in_clause}', tuple(step_ids),
+                            order_by='step_fk ASC, requirement_fk ASC')       # read 4
+            deps = _select(cursor, _DEP_COLUMNS, 'pipeline2_step_deps',
+                           f'step_fk IN {in_clause}', tuple(step_ids),
+                           order_by='step_fk ASC, id ASC')                    # read 5
+
+        requirements = []
+        requirement_ids = sorted({link['requirement_fk'] for link in links})
+        if requirement_ids:
+            requirements = _select(
+                cursor, _REQUIREMENT_COLUMNS, 'requirements',
+                f"id IN {_in_clause(len(requirement_ids))} AND creator_fk = %s",
+                tuple(requirement_ids) + (authenticated_user,), order_by='id ASC')  # read 6
+
+    model = {
+        'pipeline': pipeline, 'epics': epics, 'steps': steps,
+        'step_requirements': links, 'step_deps': deps,
+        'requirements': requirements,
+    }
+    model['derived'] = _derive(model)
+    # `uri` only ever surfaces inside a truncation marker's `resource` field
+    # (regime C, `_bounded`) — nothing parses it. It is the ROUTE's own
+    # identifier, not `darwin://pipeline2/{id}`: this payload now serves the
+    # browser directly as well as the daemon, and the browser has no
+    # `darwin://` scheme to make sense of. A daemon-only diagnostic string
+    # would be a false fidelity, not a real one.
+    return _bounded(f"pipeline2_compose/{pipeline_id}", model)
+
+
+def compose_pipeline2_epic(conn, epic_id, authenticated_user):
+    """THE epic-scoped composed render. Same shape, narrowed to one epic —
+    six reads, not five, because the epic's own row AND the pipeline's own
+    row are both required (two independent pause scopes). Returns None when
+    not found / not owned."""
+    with conn.cursor(pymysql.cursors.DictCursor) as cursor:
+        epics = _select(cursor, _EPIC_COLUMNS, 'pipeline2_epics',
+                        'id = %s AND creator_fk = %s',
+                        (epic_id, authenticated_user))                        # read 1
+        if not epics:
+            return None
+        epic = epics[0]
+
+        pipelines = _select(cursor, _PIPELINE_COLUMNS, 'pipeline2_pipelines',
+                            'id = %s AND creator_fk = %s',
+                            (epic['pipeline_fk'], authenticated_user))        # read 2
+        if not pipelines:
+            raise ValueError(
+                f"Pipeline2 epic {epic_id} names pipeline_fk="
+                f"{epic['pipeline_fk']!r}, which does not resolve for this "
+                "creator. Data integrity issue — report it.")
+        pipeline = pipelines[0]
+
+        steps = _select(cursor, _STEP_COLUMNS, 'pipeline2_steps',
+                        'epic_fk = %s AND creator_fk = %s',
+                        (epic_id, authenticated_user), order_by='id ASC')     # read 3
+        epic['step_count'] = len(steps)
+
+        links, deps = [], []
+        if steps:
+            step_ids = sorted(s['id'] for s in steps)
+            in_clause = _in_clause(len(step_ids))
+            links = _select(cursor, _LINK_COLUMNS, 'pipeline2_step_requirements',
+                            f'step_fk IN {in_clause}', tuple(step_ids),
+                            order_by='step_fk ASC, requirement_fk ASC')       # read 4
+            deps = _select(cursor, _DEP_COLUMNS, 'pipeline2_step_deps',
+                           f'step_fk IN {in_clause}', tuple(step_ids),
+                           order_by='step_fk ASC, id ASC')                    # read 5
+
+        requirements = []
+        requirement_ids = sorted({link['requirement_fk'] for link in links})
+        if requirement_ids:
+            requirements = _select(
+                cursor, _REQUIREMENT_COLUMNS, 'requirements',
+                f"id IN {_in_clause(len(requirement_ids))} AND creator_fk = %s",
+                tuple(requirement_ids) + (authenticated_user,), order_by='id ASC')  # read 6
+
+    model = {
+        'pipeline': pipeline, 'epics': [epic], 'steps': steps,
+        'step_requirements': links, 'step_deps': deps,
+        'requirements': requirements,
+    }
+    model['derived'] = _derive(model, epic_scoped=True)
+    return _bounded(f"pipeline2_compose_epic/{epic_id}", model, epic_scoped=True)

--- a/pipeline2_derive.py
+++ b/pipeline2_derive.py
@@ -1,0 +1,1200 @@
+"""Pipeline 2.0 derivation (req #3349, MOVED HERE by req #3367) — beside
+`darwin-mcp/services/pipeline_derive.py` (the 1.0 module, a different
+repository), not in place of it. Both eras run at once until 1.0 is eradicated
+(`memory/pipeline-2-first-principles.md` § 10); this module must not import
+from, call, or otherwise touch `pipeline_derive.py`, and that module is
+untouched by this requirement — byte-identical to what it was before.
+
+**This is now the ONE copy.** Req #3367 (remediation B, composing form —
+`memory/pipeline-2-orchestration-algorithm.md` § 8) moved this file out of
+`darwin-mcp/services/` and into Lambda-Rest, where `pipeline2_compose.py`
+imports it directly. darwin-mcp no longer carries a copy — its own
+`get_pipeline2_composed` / `get_pipeline2_epic_composed` are now a ONE-CALL
+passthrough to the composing route this module is imported by. `derive_plan2`
+is the "guarded call to a real deriver" that module's docstring once promised;
+the guard now lives in `pipeline2_compose.py`.
+
+## Scope — what this module is, and what it deliberately is not
+
+Req #3345's own docstring names "eligibility/state/display-order/launch-batch
+logic" as this requirement's scope, written before req #3329 authored the
+stage-3 split. That split is now the ground truth (`memory/pipeline-2-
+orchestration-algorithm.md` § 11), and the authoritative boundary is the
+verification register `scripts/swarm/verification/pipeline2_behaviours.json`
+(req #3376's coverage gate, which this requirement's own acceptance criteria
+name): DRV-001 through DRV-018, DRV-020 and DRV-021 are `req: 3349`. That set
+DOES include a plain step-scoped `eligibility` (DRV-005/006 — a pending
+step's own dep graph and its own `not_before` against the payload's clock,
+with no batch or cross-step term) and pause-driven launch suppression
+(DRV-016/017/018 — `launch_suppressed`/`suppressed_by` per row and the
+`pause` block, epic-scoped because containment gives epic pause a real scope
+key). It does NOT include reservations, debounce or commanded-requirement
+tracking (owned by req #3368 — see ENG-005/006/009, CLI-012 through CLI-016
+in the same register) — those are the ENGINE'S restatement, which consumes
+`derived['pause']`/`eligible` rather than recomputing them, and DRV-019
+("a derived block carrying no `pause` state is a hard stop") is that
+consumer's own defensive posture toward a payload this module did not
+produce, not a second implementation. There is also no `launch_batches`
+here at all — Batch does not exist in 2.0
+(`memory/pipeline-2-first-principles.md` § 6, DRV-021): the Step is the
+launch unit, so what 1.0 computes once per batch this module computes once
+per row.
+
+**Serial "turn" suppression IS this module's, and the register above is
+INCOMPLETE about it, not silent on purpose.** Req #3349's own GATE DELTAS
+section (stage-2 gate, req #3336, 2026-08-08) names it directly: "SERIAL
+MODE (req #3388, live on 1.0 since 2026-08-08): consume `execution_mode`;
+emit the `derived.serial` block mirroring 1.0's shipped shape". That
+sentence is an instruction TO this requirement, not a description of
+something already built, and `scripts/swarm/verification/
+pipeline2_behaviours.json` has no `DRV-*` entry for it at all — on ANY
+requirement, not just this one — which is a gap in the register, not
+evidence the work is out of scope. `serial_state` and `serial_deadlocks`
+below restate 1.0's `pipeline_derive.serial_state`, with one addition the
+gate delta itself calls for and 1.0 has no equivalent of: cross-epic edges
+are legal here (item 4), so a BACKWARD one — a step depending on a
+not-yet-live epic's step — is a structural deadlock under `serial` and is
+reported as a LOUD `serial-deadlock` violation rather than an
+indistinguishable stall.
+
+## What changed, item by item (req #3349's own numbering)
+
+1. **`epic_id` is a column read.** `pipeline2_steps.epic_fk` is NOT NULL, so
+   there is no tally, no tie-break, and no inheritance walk. `dominant_labels`,
+   `inherited_labels` and the `label_inherited` flag do not exist here;
+   `epic_id`, `feature_id`, `feature`, `epic_labels` and `feature_labels` do
+   not appear on a derived row — an unlabelled step cannot exist under this
+   schema, so there is nothing to borrow from a dependency. Measured against
+   the live plan (163 steps) via the 1.0 field this module's `epic_id` column
+   replaces: `label_inherited` was set on exactly 1 of 163 rows (step 11, a
+   req-less gate) — that one walk is what this item deletes, not seventeen.
+
+2. **`requirement_counts` groups by the STEP's `epic_fk`**, not by the
+   requirement's own `feature_fk` -> `epic_fk` chain — Feature does not exist
+   in 2.0, so there is no other chain to read. This changes the ANSWER where a
+   requirement's step sits under a different epic than its feature did.
+   **Measured against the live plan, 2026-08-09** (206 non-tracking
+   requirements, re-grouped by the step each is linked to in the live 1.0
+   composed read's own `derived.rows[].epic_id`, which is the field the 2.0
+   importer itself reads — see `memory/pipeline-2-data-architecture.md`
+   § 7.2): **zero requirements change bucket, and both the overall and the
+   per-epic met/total numbers are byte-identical before and after.** One
+   requirement (#3077) links two steps (14 and 15), both seated in epic 5,
+   which is also its own feature's epic — the sole multi-seat case on this
+   plan (`memory/pipeline-2-mcp-surface.md`'s "1 of 255", req #3077) does not
+   disturb the count. This is a real, reproducible measurement and not an
+   assumption that the two groupings agree in general — they diverge exactly
+   when a requirement's step is seated under a different epic than the
+   requirement's own feature, which is zero times on today's plan and is not
+   zero by construction.
+
+3. **The time-gate branch is deleted.** `pipeline2_step_deps.dep_step_fk` is
+   NOT NULL (data record § 3) — a dep row has exactly one meaning, so there is
+   no discriminator to branch on and no `time_deps` bucket to build. The
+   per-row `time_deps` field this module's rows once might have carried does
+   not exist; a step's own time gate is already visible to any reader of
+   `model['steps'][*]['not_before']` without this module re-surfacing it.
+   `now` still rides `derive_plan2`'s output, for the reason given in
+   "Scope" above.
+
+4. **Display order is a tree walk**, epic order first
+   (`memory/pipeline-2-orchestration-algorithm.md`'s gate delta, recorded on
+   req #3364): a manual `pipeline2_epics.sort_order` wins where set; epics
+   with no manual order are placed after, started ones first by an earliest-
+   activity proxy (ascending), unstarted ones last in creation (id) order.
+   See `_epic_block_order`'s docstring for the honest residue here — the
+   composed read carries no `started_at` anywhere (steps or the light
+   requirement projection), so "start" is approximated from a step's own
+   `create_ts`, not the richer timestamp chain the browser's separate
+   derivation (req #3372) can afford to read.
+
+   **CROSS-EPIC DEPENDENCY EDGES ARE LEGAL** — this requirement's own
+   stage-2 gate delta (req #3336, 2026-08-08) reverses the body text above:
+   "the walk and the banding invariant handle crossing edges exactly as the
+   live 1.0 plan already does". So `display_order` is ONE global
+   topological-then-state-band walk (structurally `pipeline_derive.
+   display_order`'s algorithm, minus the batch/stream machinery — there is
+   no batch to cluster) with epic order used as a CLUSTERING tie-break, not
+   a hard partition: a row still never renders before a dependency in
+   another epic, and epic blocks are not guaranteed contiguous, exactly as
+   1.0 is not guaranteed contiguous by first-appearance today.
+
+   **The state-banding self-check is EPIC-SCOPED, and this is not optional**
+   (`memory/pipeline-2-visualizer-design.md` § 5, req #3331's correction to
+   stage 1's claim that forbidding cross-epic edges makes the violation class
+   disappear structurally — measured FALSE: a global check over a tree-walked
+   plan reports 15 false violations on live pipeline 2, all of the form "a
+   finished epic's done steps render below an unrelated epic's still-pending
+   ones"). Scoping the check to each epic's own block is the fix, and it does
+   NOT relax away the genuine WITHIN-epic case the amended acceptance
+   criterion pins: three steps in one epic (1 pending, 2 pending, 3 done
+   depending on 2) still reports, because the greedy pass can legitimately
+   place an unrelated pending row ahead of a satisfied gate. That residue is
+   real but LATENT on the live plan — 0 of 145 dependency edges have a step
+   outranking its own gate — so a hand fixture stands in for a live-plan
+   reproduction here (see the test suite): it is the specific shape §5.3
+   names, not a question a bigger sweep would answer any differently.
+
+5. **The conformance corpus is untouched here, on purpose.** All 34 cases in
+   `tests/conformance/pipeline_conformance.json` mention `features`, and
+   re-expressing it is, in this requirement's own words, "the largest single
+   dependency here and it cannot be finished alone" — its fate depends on req
+   #3329's single-source-of-truth choice, which is now decided: **Remediation
+   B, in its composing form** (`memory/pipeline-2-orchestration-algorithm.md`
+   § 8.1 — one derivation, moved into Lambda-Rest behind a composing route;
+   `pipelineModel.js` deleted). Stated as that record instructs: **under B the
+   corpus stops being a drift control and becomes an ordinary test suite of
+   ONE implementation** — it is not deleted, its 34 cases still encode real
+   derivation behaviour, but re-pointing and re-expressing it in the 2.0 shape
+   is req #3367's job ("the corpus re-pointed at one target"), which depends
+   on this requirement rather than the reverse. There is, today, no second 2.0
+   implementation for a corpus to detect drift against in the first place —
+   `pipelineModel.js`'s 2.0 counterpart has never been built and, under B, one
+   never will be. This module's own test suite (`tests/unit/
+   test_pipeline2_derive.py`) is the ordinary-test-suite half of that answer
+   in the meantime.
+
+6. **Tests** live in `tests/unit/test_pipeline2_derive.py`: one per deleted
+   field asserting it is absent from a derived row, the tree-walk order
+   including the amended three-step case, and `requirement_counts` grouping
+   by the seated epic.
+"""
+
+import re
+from datetime import datetime, timezone
+
+__all__ = [
+    'STEP_DONE', 'STEP_RUNNING', 'STEP_PENDING',
+    'TERMINAL_REQUIREMENT_STATUSES', 'LAUNCHABLE_REQUIREMENT_STATUSES',
+    'PAUSED_STATUS', 'MODE_PARALLEL', 'MODE_SERIAL',
+    'is_tracking_requirement', 'derive_step_state',
+    'build_plan_rows', 'display_order', 'verify_order', 'eligibility',
+    'pause_state', 'serial_state', 'requirement_counts', 'derive_plan2',
+]
+
+STEP_DONE = 'done'
+STEP_RUNNING = 'running'
+STEP_PENDING = 'pending'
+
+# Requirement statuses that close a step (design rule 1). Byte-identical to
+# `pipeline_derive.TERMINAL_REQUIREMENT_STATUSES` — this fact about the state
+# machine did not change with Feature or containment, so it is not "ported",
+# it is simply also true here.
+TERMINAL_REQUIREMENT_STATUSES = ('met', 'deferred', 'wontfix')
+
+# The ONLY status a `/swarm-start` argument may carry (req #3360, carried
+# forward as gate delta F9 on THIS requirement — "without this the fix seated
+# at step 266 dies"). See `pipeline_derive.LAUNCHABLE_REQUIREMENT_STATUSES`
+# for the full reasoning on why `approved` and `development` are excluded;
+# that reasoning is a property of the requirement state machine, not of
+# Feature or containment, and is unchanged here.
+LAUNCHABLE_REQUIREMENT_STATUSES = ('swarm_ready',)
+
+# Why a requirement id is not in a step's launch argument list. One flat
+# string per exclusion, `"<req_id> <reason>"` — matches
+# `pipeline_derive`'s shape so a consumer reading both eras' payloads reads
+# one grammar, not two.
+EXCLUDED_CONTAINER = 'tracking container'
+EXCLUDED_UNRESOLVED = 'unresolved — not in the composed read'
+EXCLUDED_NO_STATUS = 'no status'
+
+# The enum behind a step's `no_launch_reason` (gate delta F9). Per STEP, not
+# per batch — 2.0 has no batch.
+BLOCK_NO_LINKS = 'no-links'
+BLOCK_CONTAINERS = 'containers'
+BLOCK_NOT_READY = 'not-ready'
+
+# The one value that means "do not swarm-start this scope" (req #3223),
+# shared by `pipelines.pipeline_status`/`epics.epic_status` and their 2.0
+# counterparts — one word, one meaning, at both scopes, in both eras.
+PAUSED_STATUS = 'paused'
+
+# How a plan runs its epics (req #3388, gate delta on THIS requirement:
+# "consume `execution_mode`; emit the `derived.serial` block mirroring 1.0's
+# shipped shape"). `parallel` is every epic at once and is the DEFAULT — an
+# ABSENT value reads as parallel, matching every `pipeline2_pipelines` row
+# written before this column existed a meaning for.
+MODE_PARALLEL = 'parallel'
+MODE_SERIAL = 'serial'
+
+_STATE_RANK = {STEP_DONE: 0, STEP_RUNNING: 1, STEP_PENDING: 2}
+_RUN_RANK = {'auto': 0, 'manual': 1}
+
+# Byte-identical to `pipeline_derive._TIMESTAMP_RE` / `_to_epoch` — the
+# grammar and the parse hazards it guards against (naive-UTC ambiguity,
+# `datetime.fromisoformat`'s grammar widening across Python versions, NaN/inf
+# poisoning a comparison) are properties of the TIMESTAMP data type, not of
+# Feature or containment, so this is restated rather than imported (module
+# docstring: this module must not import `pipeline_derive`).
+_TIMESTAMP_RE = re.compile(
+    r'^([0-9]{4})-([0-9]{2})-([0-9]{2})'
+    r'(?:[ T]([0-9]{2}):([0-9]{2})(?::([0-9]{2})(?:\.([0-9]{1,6}))?)?'
+    r'(Z|z|[+-][0-9]{2}:[0-9]{2})?)?\Z', re.ASCII)
+
+
+def _to_epoch(value):
+    """Darwin timestamps are NAIVE UTC; see `pipeline_derive._to_epoch` for
+    the full parse-hazard rationale this restates verbatim. Returns `None`
+    for anything unparseable — the caller treats that as NOT ELIGIBLE, never
+    as passed."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        parsed = value
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.timestamp()
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        try:
+            epoch = float(value)
+        except OverflowError:
+            return None
+        return None if epoch != epoch or epoch in (float('inf'), float('-inf')) else epoch
+    if not isinstance(value, str):
+        return None
+    match = _TIMESTAMP_RE.match(value)
+    if not match:
+        return None
+    year, month, day, hour, minute, second, fraction, zone = match.groups()
+    milli = int((fraction + '00')[:3]) if fraction else 0
+    try:
+        parsed = datetime(int(year), int(month), int(day),
+                          int(hour or 0), int(minute or 0), int(second or 0),
+                          milli * 1000, tzinfo=timezone.utc)
+    except ValueError:
+        return None
+    epoch = parsed.timestamp()
+    if zone and zone not in ('Z', 'z'):
+        offset = int(zone[1:3]) * 60 + int(zone[4:6])
+        if int(zone[1:3]) > 23 or int(zone[4:6]) > 59:
+            return None
+        epoch -= (-offset if zone[0] == '-' else offset) * 60
+    return epoch
+
+
+# ---------------------------------------------------------------------------
+# Requirement-level derivation — unchanged by Feature's removal or epic_fk's
+# arrival, so this is not a redesign, it is the same fact restated where this
+# module needs it.
+# ---------------------------------------------------------------------------
+
+def is_tracking_requirement(req):
+    """True when a requirement carries the req #3123 CONTAINER flag.
+
+    Identical rule and identical numeric coercion to
+    `pipeline_derive.is_tracking_requirement` — see that module's docstring
+    for why a bare truthiness check is wrong on the string `"0"`. Two engines
+    reading the same `requirements.tracking` column have to agree, so this is
+    restated rather than imported (`pipeline2_derive` must not import from
+    `pipeline_derive` — module docstring).
+    """
+    value = (req or {}).get('tracking')
+    if value is None or value == '':
+        return False
+    if isinstance(value, bool):
+        return value
+    try:
+        return float(value) != 0
+    except (TypeError, ValueError):
+        return False
+
+
+def _index_by_id(rows):
+    return {row['id']: row for row in (rows or []) if row and 'id' in row}
+
+
+def _id_sort_key(value):
+    """Numbers before strings, each in their own natural order — see
+    `pipeline_derive._id_sort_key`. Restated for the same reason as above."""
+    try:
+        return (0, float(value), '')
+    except (TypeError, ValueError):
+        return (1, 0.0, str(value))
+
+
+def _linked_req_ids(step_id, model):
+    """Requirement ids linked to a step, in junction order."""
+    return [link['requirement_fk'] for link in (model.get('step_requirements') or [])
+            if link.get('step_fk') == step_id]
+
+
+def _split_launchable(req_ids, tracking_ids, reqs_by_id):
+    """Gate delta F9 (req #3360's rule, restated for 2.0). Returns
+    `(launch_ids, excluded)` — the ids a step's `/swarm-start` may carry, and
+    one record per id it may not, each carrying the reason. Order is the
+    step's own junction order — the command a reader is told to run must be
+    stable across cycles."""
+    tracking = set(tracking_ids or [])
+    launch_ids, excluded = [], []
+
+    def note(rid, reason):
+        excluded.append('%s %s' % (rid, reason))
+
+    for rid in (req_ids or []):
+        if rid in tracking:
+            note(rid, EXCLUDED_CONTAINER)
+            continue
+        req = reqs_by_id.get(rid)
+        if req is None:
+            note(rid, EXCLUDED_UNRESOLVED)
+            continue
+        status = req.get('requirement_status')
+        if status in LAUNCHABLE_REQUIREMENT_STATUSES:
+            launch_ids.append(rid)
+        else:
+            note(rid, status if status else EXCLUDED_NO_STATUS)
+    return launch_ids, excluded
+
+
+def _launch_block(req_ids, tracking_ids, launch_ids):
+    """WHICH of the three no-command cases this step is in — the enum, not
+    the sentence. `None` when something IS launchable. Per STEP: 2.0 has no
+    batch to ask this of, so there is exactly one member, always."""
+    if launch_ids:
+        return None
+    if not req_ids:
+        return BLOCK_NO_LINKS
+    if set(req_ids) <= set(tracking_ids):
+        return BLOCK_CONTAINERS
+    return BLOCK_NOT_READY
+
+
+_NO_LAUNCH_SENTENCE = {
+    BLOCK_NO_LINKS: lambda excluded: 'no linked requirements — nothing to launch',
+    BLOCK_CONTAINERS: lambda excluded: ('every linked requirement is a tracking '
+                                        'container — nothing to launch'),
+    BLOCK_NOT_READY: lambda excluded: (
+        'nothing launchable — only %s launches: %s'
+        % (', '.join(LAUNCHABLE_REQUIREMENT_STATUSES), ', '.join(excluded))),
+}
+
+
+def _no_launch_reason(block, excluded):
+    return _NO_LAUNCH_SENTENCE[block](excluded)
+
+
+def derive_step_state(step, linked_reqs):
+    """Design rule 1: STEP STATE IS DERIVED, NEVER STORED-BY-HAND.
+
+    Byte-identical rule to `pipeline_derive.derive_step_state` — Feature's
+    removal and containment change WHERE a step's epic comes from, not how its
+    state is computed. Any gating requirement in `development` -> running; all
+    terminal -> done; else pending. With no gating requirements the step's own
+    `completed_at` stamp decides.
+    """
+    reqs = [r for r in (linked_reqs or []) if r]
+    gating = [r for r in reqs if not is_tracking_requirement(r)]
+    if not gating:
+        return STEP_DONE if (step or {}).get('completed_at') else STEP_PENDING
+    if any(r.get('requirement_status') == 'development' for r in gating):
+        return STEP_RUNNING
+    if all(r.get('requirement_status') in TERMINAL_REQUIREMENT_STATUSES
+           for r in gating):
+        return STEP_DONE
+    return STEP_PENDING
+
+
+# ---------------------------------------------------------------------------
+# Build plan rows
+# ---------------------------------------------------------------------------
+
+def build_plan_rows(model):
+    """Join the model tables into self-contained plan rows, in steps-array
+    (insertion) order — callers MUST reorder via `display_order` before
+    rendering or sequencing, exactly as 1.0 requires of its own rows.
+
+    `epic_id` is `step['epic_fk']`, A COLUMN READ (item 1) — no tally, no
+    tie-break, no inheritance walk, and no `epic`/`feature`/`feature_id`/
+    `epic_labels`/`feature_labels`/`label_inherited` on the row: none of
+    those concepts exist once a step's epic is a NOT NULL column. A consumer
+    wanting the epic's title reads it off `model['epics']` by id — this
+    module does not duplicate data the composed read already carries once.
+
+    `dep_ids` come from `pipeline2_step_deps`, where every row is a plain
+    step-to-step edge (`dep_step_fk` NOT NULL, data record § 3) — there is no
+    second condition kind to bucket separately, so unlike
+    `pipeline_derive.build_plan_rows` there is no `time_deps` output at all
+    (item 3).
+    """
+    reqs_by_id = _index_by_id(model.get('requirements'))
+    steps = model.get('steps') or []
+
+    dep_ids_by_step = {}
+    for dep in model.get('step_deps') or []:
+        dep_ids_by_step.setdefault(dep['step_fk'], []).append(dep['dep_step_fk'])
+
+    rows = []
+    for step in steps:
+        req_ids = _linked_req_ids(step['id'], model)
+        linked = [reqs_by_id[rid] for rid in req_ids if rid in reqs_by_id]
+        unresolved = [rid for rid in req_ids if rid not in reqs_by_id]
+        tracking_ids = [rid for rid in req_ids
+                        if is_tracking_requirement(reqs_by_id.get(rid))]
+        launch_ids, launch_excluded = _split_launchable(req_ids, tracking_ids,
+                                                         reqs_by_id)
+        block = _launch_block(req_ids, tracking_ids, launch_ids)
+        rows.append({
+            'id': step['id'],
+            'title': step.get('title'),
+            'run': step.get('run') or 'auto',
+            'notes': step.get('notes'),
+            'completed_at': step.get('completed_at'),
+            'state': derive_step_state(step, linked),
+            'epic_id': step.get('epic_fk'),
+            'req_ids': req_ids,
+            'tracking_req_ids': tracking_ids,
+            'unresolved_req_ids': unresolved,
+            'launch_req_ids': launch_ids,
+            'launch_excluded': launch_excluded,
+            'launch_block': block,
+            'swarm_start_command': (
+                f"/swarm-start {' '.join(str(r) for r in launch_ids)}"
+                if launch_ids else None),
+            'no_launch_reason': (None if launch_ids
+                                 else _no_launch_reason(block, launch_excluded)),
+            'dep_ids': dep_ids_by_step.get(step['id'], []),
+            # Internal to this module's ordering/eligibility passes only —
+            # never on the payload a caller of `derive_plan2` sees (stripped
+            # in `derive_plan2`'s own row projection, matching 1.0's compact-
+            # block discipline, `test_the_derived_block_is_compact_ids_and_
+            # enums_only`'s 2.0 counterpart). `_not_before` is the raw gate
+            # `eligibility()` resolves into the public boolean `eligible` —
+            # the raw value itself is item 3's `time_deps` deletion target
+            # and must not reappear on the public row.
+            '_create_ts': step.get('create_ts'),
+            '_not_before': step.get('not_before'),
+        })
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Ordering — the tree walk (item 4)
+# ---------------------------------------------------------------------------
+
+def _epic_block_order(epics, rows_by_id):
+    """Epic block order: manual `sort_order` wins where set; else started
+    epics by an earliest-activity proxy ascending; unstarted epics after, in
+    creation (id) order. (`memory/pipeline-2-orchestration-algorithm.md`'s
+    gate delta, recorded on req #3364.)
+
+    **The residue, stated plainly.** The browser's own derivation of "start"
+    (req #3372) reads a requirement's `started_at`/`completed_at` — columns
+    this composed read's light requirement projection does not carry
+    (`memory/pipeline-2-mcp-surface.md` § 6.2's `_REQUIREMENT_FIELDS`), and
+    which no `pipeline2_*` table carries at the epic level either. The only
+    timestamp available to a server-side reader of THIS payload is a step's
+    own `create_ts`. So "start" here is approximated as the earliest
+    `create_ts` among an epic's own non-pending (running or done) steps —
+    when a step actually started work is not recoverable from this payload,
+    when it was authored into the plan is. This is a proxy, not a
+    reproduction of the browser's richer chain, and a future session
+    reconciling the two derivations should re-measure rather than assume
+    they agree.
+
+    An epic with zero non-pending steps (including an empty epic) is
+    "unstarted" and sorts by id — AUTO_INCREMENT order is creation order on
+    this schema, the same idiom `pipeline_derive._id_sort_key` documents.
+    """
+    manual, derived = [], []
+    for epic in epics:
+        eid = epic['id']
+        sort_order = epic.get('sort_order')
+        epic_row_ids = [rid for rid, row in rows_by_id.items()
+                        if row.get('epic_id') == eid]
+        started_ts = [rows_by_id[rid]['_create_ts'] for rid in epic_row_ids
+                     if rows_by_id[rid]['state'] != STEP_PENDING
+                     and rows_by_id[rid].get('_create_ts')]
+        entry = {'id': eid, 'sort_order': sort_order,
+                 'started': bool(started_ts),
+                 'start_proxy': min(started_ts) if started_ts else ''}
+        (manual if sort_order is not None else derived).append(entry)
+
+    manual.sort(key=lambda e: (_id_sort_key(e['sort_order']), e['id']))
+
+    def derived_key(e):
+        if e['started']:
+            return (0, e['start_proxy'], e['id'])
+        return (1, '', e['id'])
+
+    derived.sort(key=derived_key)
+    return [e['id'] for e in manual] + [e['id'] for e in derived]
+
+
+def display_order(rows, epics):
+    """Design rule 3, re-derived for containment — and CORRECTED against the
+    stage-2 gate delta on this requirement (req #3336, 2026-08-08): **cross-
+    epic dependency edges are LEGAL**, reversing item 4's own body text
+    ("a dependency edge cannot cross an epic"). The gate delta's instruction
+    is explicit: "the walk and the banding invariant handle crossing edges
+    exactly as the live 1.0 plan already does" — so this is ONE global
+    topological-then-state-band walk, structurally identical to
+    `pipeline_derive.display_order`'s core algorithm, with epic order
+    (`_epic_block_order`'s override-tier sequence) standing in for 1.0's
+    first-appearance `epic_idx` as a clustering tie-break — NOT a hard
+    partition. What is dropped relative to 1.0 is only the batch/stream
+    apparatus: 2.0 has no batch (`memory/pipeline-2-first-principles.md`
+    § 6), so `stream()`/`group_tail` and everything that clustered pending
+    batch-mates do not exist here.
+
+    A row still never renders before a dependency, whichever epic that
+    dependency belongs to. Epic blocks are consequently NOT guaranteed
+    contiguous in the presence of a crossing edge — exactly as 1.0 is not
+    guaranteed contiguous by first-appearance today — but `epic_idx` pulls
+    same-epic rows together wherever topology leaves a choice, which is what
+    measurement A (`memory/pipeline-2-visualizer-design.md` § 5.2) shows
+    costs nothing on the live plan's 9 crossing edges: 0 state-banding
+    violations once that check is scoped per epic (`verify_order` below).
+
+    Rows carrying an `epic_id` absent from `epics` (a truncated composed read
+    withheld that epic's own row) sort after every known epic, in ascending
+    epic-id order — the safe direction, matching 1.0's dangling-dependency
+    posture of reporting rather than guessing.
+
+    Cycle contract, matching 1.0: detect, report, deterministic fallback to
+    stored (insertion) order for whatever is left standing.
+
+    Returns `{rows, cycle_detected, cycle_step_ids, duplicate_step_ids,
+    epic_order}`.
+    """
+    duplicate_step_ids = []
+    seen_ids = set()
+    for row in rows:
+        if row['id'] in seen_ids:
+            if row['id'] not in duplicate_step_ids:
+                duplicate_step_ids.append(row['id'])
+        else:
+            seen_ids.add(row['id'])
+
+    by_id = {row['id']: row for row in rows}       # last occurrence wins on a dup
+    dedup_rows = list(by_id.values())
+    epic_ids_known = {epic['id'] for epic in (epics or [])}
+
+    epic_order = _epic_block_order(epics or [], by_id)
+    unresolved_epic_ids = sorted(
+        {row['epic_id'] for row in dedup_rows
+         if row.get('epic_id') not in epic_ids_known},
+        key=_id_sort_key)
+    full_epic_order = epic_order + unresolved_epic_ids
+    epic_pos = {eid: position for position, eid in enumerate(full_epic_order)}
+
+    def epic_idx(row):
+        return epic_pos.get(row.get('epic_id'), len(full_epic_order))
+
+    idx = {row['id']: position for position, row in enumerate(dedup_rows)}
+
+    def num_id(row):
+        try:
+            return float(row['id'])
+        except (TypeError, ValueError):
+            return float(idx[row['id']])
+
+    remaining = {row['id']: row for row in dedup_rows}
+    out, pos = [], {}
+    cycle_detected, cycle_step_ids = False, []
+
+    def sort_key(row):
+        if row.get('state') == STEP_DONE:
+            # Storage position is the FINAL tie-break for done work, matching
+            # 1.0 — done history is chronological and insertion order is the
+            # honest record of it, where pending/running work has none yet.
+            return (0, epic_idx(row), float(idx[row['id']]))
+        anchor = max([-1] + [pos[d] for d in (row.get('dep_ids') or []) if d in pos])
+        band = 1 if row.get('state') == STEP_RUNNING else 2
+        return (band, float(anchor), epic_idx(row),
+                _RUN_RANK.get(row.get('run') or 'auto', 0), num_id(row))
+
+    while remaining:
+        avail = [row for row in remaining.values()
+                 if all(d not in remaining for d in (row.get('dep_ids') or []))]
+        if not avail:
+            rest = sorted(remaining.values(), key=lambda r: idx[r['id']])
+            cycle_detected = True
+            cycle_step_ids = [row['id'] for row in rest]
+            out.extend(rest)
+            break
+        pick = min(avail, key=sort_key)
+        pos[pick['id']] = len(out)
+        out.append(pick)
+        del remaining[pick['id']]
+
+    return {'rows': out, 'cycle_detected': cycle_detected,
+            'cycle_step_ids': cycle_step_ids,
+            'duplicate_step_ids': duplicate_step_ids,
+            'epic_order': full_epic_order}
+
+
+def _epic_banding_violations(epic_rows, depends_on):
+    """The state-banding invariant, compared over ONE epic's own rows only —
+    item 4's epic-scoped self-check (`memory/pipeline-2-visualizer-design.md`
+    § 5.4, measurement D). A band inversion is a violation only when it was
+    AVOIDABLE: the lower-band row does not depend, TRANSITIVELY, on the
+    higher-band row it renders below.
+
+    `depends_on` is the caller's GLOBAL closure (over every row in the whole
+    plan, not just this epic) — this is corrected from an earlier version
+    that computed the closure locally per epic, which was WRONG: cross-epic
+    dependency edges are legal, so a transitive path can legitimately leave
+    this epic and come back (A -> B in another epic -> C, back in this one),
+    and a closure that cannot see B reports a false "unavoidable" inversion
+    between A and C. Only the COMPARISON — which pairs of rows are even
+    checked against each other — is epic-scoped; what counts as "avoidable"
+    is a fact about the whole dependency graph and must be computed there.
+    (Measured over 3000 fuzzed plans: an epic-local closure produced 50 false
+    positives beyond the 386 a global closure finds — 11.5% of the total.)
+
+    This is the check the amended acceptance criterion's three-step case
+    exercises: `1 pending, 2 pending, 3 done depending on 2` in one epic
+    reports `3` rendering below `1`, because `1` is not a dependency of `3`
+    and the greedy topological pass had no reason to place it after `2, 3`.
+    """
+    def band_of(row):
+        return _STATE_RANK.get(row.get('state'), 2)
+
+    violations = []
+    for position, row in enumerate(epic_rows):
+        band = band_of(row)
+        avoidable = [prev for prev in epic_rows[:position]
+                     if band_of(prev) > band and prev['id'] not in depends_on(row['id'])]
+        if avoidable:
+            worst = avoidable[-1]
+            violations.append({
+                'invariant': 'state-banding', 'step_ids': [row['id'], worst['id']],
+                'message': (f"{row.get('state')} step {row['id']} renders below "
+                            f"{worst.get('state')} step {worst['id']}, which it "
+                            "does not depend on — done>running>pending banding "
+                            "broken (epic-scoped)"),
+            })
+    return violations
+
+
+def verify_order(rows, epic_scoped=False):
+    """Design rule 3 self-check — structured violations, NEVER raised.
+
+    `duplicate-id`, `cycle` and `topology` stay plan-wide, because they must:
+    cross-epic dependency edges are LEGAL (gate delta, req #3336,
+    2026-08-08), so a dependency can genuinely name a step in a different
+    epic and these invariants have to see the whole graph to mean anything.
+    `state-banding` is the one invariant that MUST be epic-scoped instead
+    (item 4's amendment, `memory/pipeline-2-visualizer-design.md` § 5) — a
+    global check over a plan clustered-but-not-partitioned by epic reports
+    false violations for every finished epic that happens to render above an
+    unrelated epic still holding pending work (measurement C: 15 false
+    positives on the live plan), which is not a defect, it is what
+    containment asks for. `_epic_banding_violations` groups `rows` by
+    `epic_id` wherever they fall in the global order — it does not require
+    (and `display_order` does not guarantee) that one epic's rows are
+    contiguous, and it is handed a GLOBAL `depends_on` closure so a
+    transitive path through another epic is still seen.
+
+    `dangling-dependency` is CONDITIONAL on `epic_scoped`, and this is the
+    fix for a real defect a code review caught: `get_pipeline2_epic_composed`
+    narrows `steps` at the gateway (`epic_fk = E`) but fetches `step_deps` by
+    `step_fk`, so an OUTGOING cross-epic edge arrives with its `dep_step_fk`
+    pointing at a step this payload never fetched. Under `epic_scoped=True`
+    that is EXPECTED — not a defect in the plan, a property of the scope —
+    and reporting it as `dangling-dependency` (which reads as data loss or a
+    stale FK) sends a reader chasing a corruption that does not exist while
+    `eligibility` correctly, silently, and PERMANENTLY refuses to launch a
+    step that was actually ready. The fix is not to make it launchable —
+    this render genuinely cannot see whether the out-of-scope dependency is
+    done — it is to say so honestly: those ids are collected into
+    `out_of_scope_dep_ids` instead of a violation, and a caller wanting the
+    true state reads the whole-plan render. `epic_scoped=False` (the
+    default, matching `get_pipeline2_composed`) keeps 1.0's posture: every
+    epic is present, so a dep not in `rows` is genuinely dangling — a
+    truncated payload or a real data defect — and stays a loud violation.
+
+    There is no `batch-contiguity` invariant here — 2.0 has no batch.
+
+    Returns `(violations, out_of_scope_dep_ids)`.
+    """
+    violations = []
+    posn = {row['id']: position for position, row in enumerate(rows)}
+
+    seen_ids, dup_ids = set(), []
+    for row in rows:
+        if row['id'] in seen_ids:
+            if row['id'] not in dup_ids:
+                dup_ids.append(row['id'])
+        else:
+            seen_ids.add(row['id'])
+    if dup_ids:
+        violations.append({
+            'invariant': 'duplicate-id', 'step_ids': dup_ids,
+            'message': (f"duplicate step ids {', '.join(str(i) for i in dup_ids)} — "
+                        "rows collapse silently; the rendered plan is missing steps"),
+        })
+
+    out_of_scope = set()
+    for row in rows:
+        for dep in (row.get('dep_ids') or []):
+            if dep in posn:
+                continue
+            if epic_scoped:
+                out_of_scope.add(dep)
+            else:
+                violations.append({
+                    'invariant': 'dangling-dependency', 'step_ids': [row['id'], dep],
+                    'message': (f"step {row['id']} depends on step {dep}, which is "
+                                "not in the rendered rows"),
+                })
+
+    peeled, progress = set(), True
+    while progress:
+        progress = False
+        for row in rows:
+            if row['id'] in peeled:
+                continue
+            if all(d not in posn or d in peeled for d in (row.get('dep_ids') or [])):
+                peeled.add(row['id'])
+                progress = True
+    stuck = [row['id'] for row in rows if row['id'] not in peeled]
+    if stuck:
+        violations.append({
+            'invariant': 'cycle', 'step_ids': stuck,
+            'message': (f"dependency cycle: steps {', '.join(str(i) for i in stuck)} "
+                        "are in or gated behind a cycle; display fell back to "
+                        "stored order"),
+        })
+
+    for row in rows:
+        for dep in (row.get('dep_ids') or []):
+            if dep in posn and posn[dep] > posn[row['id']]:
+                violations.append({
+                    'invariant': 'topology', 'step_ids': [row['id'], dep],
+                    'message': f"step {row['id']} renders before its dependency {dep}",
+                })
+
+    # ONE global closure, over every row regardless of epic — see
+    # `_epic_banding_violations`'s docstring for why a per-epic closure is
+    # wrong (a cross-epic transitive path is invisible to it).
+    by_id = {row['id']: row for row in rows}
+    closure = {}
+
+    def depends_on(step_id):
+        if step_id in closure:
+            return closure[step_id]
+        out = set()
+        closure[step_id] = out
+        row = by_id.get(step_id)
+        for dep in (row or {}).get('dep_ids') or []:
+            if dep not in posn:
+                continue
+            out.add(dep)
+            out.update(depends_on(dep))
+        return out
+
+    # `rows` arrive in epic-block order (`display_order`'s contract), so a
+    # plain first-appearance walk visits each epic's rows together and in the
+    # same order the caller rendered them — nothing here re-derives epic
+    # order a second time.
+    by_epic = {}
+    for row in rows:
+        by_epic.setdefault(row.get('epic_id'), []).append(row)
+    for epic_rows in by_epic.values():
+        violations.extend(_epic_banding_violations(epic_rows, depends_on))
+
+    return violations, sorted(out_of_scope, key=_id_sort_key)
+
+
+# ---------------------------------------------------------------------------
+# Eligibility (DRV-005/006) — a plain per-step predicate, no batch term
+# ---------------------------------------------------------------------------
+
+def eligibility(row, by_id, now=None):
+    """A pending row is eligible when every dependency is `done` AND its own
+    `not_before` (if any) has passed relative to the caller-supplied `now` —
+    this module never reads the clock itself (`derive_plan2` is the one
+    caller, and it is told `now` by ITS caller for the same reason
+    `pipeline_derive.eligibility` documents: a stale clock must be visible as
+    stale, not invisible).
+
+    No batch term exists here — 1.0's `eligibility` is keyed off a batch's
+    shared launch key; 2.0 has no batch, so this is purely a function of one
+    row's own `dep_ids` and `_not_before` (DRV-005). No `now` — or an
+    unparseable gate — while a gate exists means NOT eligible, never passed:
+    the safe direction, matching 1.0's posture exactly.
+    """
+    if row.get('state') != STEP_PENDING:
+        return False
+    for dep_id in (row.get('dep_ids') or []):
+        dep = by_id.get(dep_id)
+        if not dep or dep.get('state') != STEP_DONE:
+            return False
+    gate = row.get('_not_before')
+    if not gate:
+        return True
+    now_epoch = _to_epoch(now)
+    if now_epoch is None:
+        return False
+    gate_epoch = _to_epoch(gate)
+    if gate_epoch is None or gate_epoch > now_epoch:
+        return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Pause (DRV-016/017/018) — launch suppression, epic-scoped
+# ---------------------------------------------------------------------------
+
+def pause_state(model, rows):
+    """Which scopes are paused, and therefore which steps must not be
+    launched — restated for containment from `pipeline_derive.pause_state`,
+    and simpler here: a step has exactly ONE epic (a column, not a
+    tie-broken tally), so "the step's dominant epic is paused" collapses to
+    a plain membership test.
+
+    TWO SCOPES, ONE RULE, unchanged from 1.0: a step is suppressed when its
+    PLAN is paused, or when its OWN epic is paused (DRV-017 — an epic pause
+    suppresses that epic's steps and not its neighbour, because containment
+    gives epic pause a real scope key no 1.0 epic ever had). An epic pause
+    binds a WHOLE-PLAN orchestrator too (DRV-018): suppression is a property
+    of the STEP, computed here regardless of which scope is asking, so there
+    is nothing for a whole-plan orchestrator to opt out of.
+
+    `eligible` (from `eligibility` above) is left UNCHANGED by this function
+    (DRV-016) — it is called separately, over the same rows, and neither
+    writes the other's field. A consumer distinguishes "eligible and
+    suppressed" (waits on a person) from "not eligible" (waits on a gate) by
+    reading both.
+
+    `suppressed_by` is a LIST: when both clauses fire, naming only one would
+    leave a reader who unpaused just the plan surprised the step is still
+    held. A missing `epic_status` reads as `active` — the column's own
+    default, and what every row written before an epic pause ever existed
+    is.
+    """
+    pipeline = model.get('pipeline') or {}
+    pipeline_status = pipeline.get('pipeline_status')
+    pipeline_paused = pipeline_status == PAUSED_STATUS
+
+    paused_epics = {epic.get('id') for epic in model.get('epics') or []
+                    if epic.get('epic_status') == PAUSED_STATUS
+                    and epic.get('id') is not None}
+
+    suppressed = []
+    for row in rows:
+        reasons = []
+        if pipeline_paused:
+            reasons.append('pipeline')
+        if row.get('epic_id') in paused_epics:
+            reasons.append('epic')
+        row['launch_suppressed'] = bool(reasons)
+        row['suppressed_by'] = reasons
+        if reasons:
+            suppressed.append(row['id'])
+
+    return {
+        'pipeline_status': pipeline_status,
+        'pipeline_paused': pipeline_paused,
+        'paused_epic_ids': sorted(paused_epics, key=_id_sort_key),
+        # In DISPLAY order — `derive_plan2` calls this after `display_order`,
+        # so `rows` already carries the caller's rendered sequence.
+        'suppressed_step_ids': suppressed,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Serial execution (gate delta, req #3388 — "live on 1.0 since 2026-08-08")
+# ---------------------------------------------------------------------------
+
+def serial_state(model, rows, epic_order):
+    """Which epic's turn it is, and therefore which steps must WAIT for it —
+    the `derived.serial` block, mirroring 1.0's shipped shape
+    (`pipeline_derive.serial_state`): `{execution_mode, serial, epic_order,
+    closed_epic_ids, live_epic_id, waiting_epic_ids, held_step_ids}`.
+
+    `execution_mode` is the ONE stored fact — an intention, like a pause.
+    Everything else is DERIVED: an epic is CLOSED when every step it owns is
+    `done`; the LIVE epic is the first one in `epic_order` that is not
+    closed; an epic is BEHIND, LIVE, or AHEAD, and only the ones AHEAD are
+    held.
+
+    **`epic_order` is the caller's — this module's OWN tree-walk order
+    (`display_order`'s `epic_order`), not a re-derivation from first
+    appearance in `rows`.** This is a deliberate divergence from 1.0:
+    1.0 has no stored or derived epic-order concept at all before this
+    field exists, so its `serial_state` had to invent one from first
+    appearance; 2.0 already has a principled epic order (item 4's
+    override-tier rule — manual `sort_order`, else earliest-activity, else
+    creation order), and re-deriving a second, cruder one here would be two
+    answers to one question.
+
+    A step whose epic is not the live one is suppressed with reason `turn`,
+    appended to `suppressed_by` (which `pause_state` — called first — has
+    already populated), never replacing it: a step held by both a pause and
+    a turn must name both. A step with NO epic label cannot happen under
+    2.0's `epic_fk NOT NULL` (unlike 1.0, where a req-less step could carry
+    no label at all) — so unlike `pipeline_derive.serial_state` there is no
+    "no epic label -> never held" carve-out to make here; every step has an
+    epic and therefore a turn.
+
+    Under `parallel` nothing is suppressed and no row is touched — the order
+    and closure facts are still computed and returned, because they cost
+    nothing over rows already in hand.
+    """
+    pipeline = model.get('pipeline') or {}
+    mode = pipeline.get('execution_mode') or MODE_PARALLEL
+    serial = mode == MODE_SERIAL
+
+    rows_by_epic = {}
+    for row in rows:
+        rows_by_epic.setdefault(row.get('epic_id'), []).append(row)
+
+    closed_epic_ids = [
+        epic_id for epic_id in epic_order
+        if all(row.get('state') == STEP_DONE
+               for row in rows_by_epic.get(epic_id, []))
+    ]
+    closed = set(closed_epic_ids)
+
+    live_epic_id = None
+    for epic_id in epic_order:
+        if epic_id not in closed:
+            live_epic_id = epic_id
+            break
+
+    waiting = {epic_id for epic_id in epic_order
+               if epic_id not in closed and epic_id != live_epic_id}
+
+    held = []
+    if serial and live_epic_id is not None:
+        for row in rows:
+            epic_id = row.get('epic_id')
+            if epic_id not in waiting:
+                continue
+            row['suppressed_by'] = list(row.get('suppressed_by') or []) + ['turn']
+            row['launch_suppressed'] = True
+            held.append(row['id'])
+
+    return {
+        'execution_mode': mode,
+        'serial': serial,
+        'epic_order': list(epic_order),
+        'closed_epic_ids': closed_epic_ids,
+        'live_epic_id': live_epic_id,
+        'waiting_epic_ids': [e for e in epic_order if e in waiting],
+        'held_step_ids': held,
+    }
+
+
+def serial_deadlocks(rows, epic_order, serial):
+    """A BACKWARD cross-epic dependency edge on a `serial` plan — the gate
+    delta's own new invariant, unique to 2.0: cross-epic edges are legal
+    (item 4's gate delta), so a step can name a dependency in an epic that
+    has not had its turn yet. Under serial execution that dependency is
+    HELD by `serial_state` until its own epic goes live — which can never
+    happen while it is itself blocking an earlier epic from closing. That is
+    a structural deadlock, not a data defect that resolves itself, and it
+    must be LOUD (`design rule 7`) rather than a silent stall indistinguishable
+    from ordinary in-progress work.
+
+    A "backward" edge is one where the DEPENDENCY's epic sits AFTER the
+    DEPENDING step's epic in `epic_order` — the depending step's turn
+    finishes before the dependency's turn even starts. Only meaningful under
+    `serial`; a parallel plan has no turn order for an edge to violate.
+
+    Returns a list of `serial-deadlock` violations, empty when `serial` is
+    False or no edge is backward.
+    """
+    if not serial:
+        return []
+    epic_pos = {eid: position for position, eid in enumerate(epic_order)}
+    by_id = {row['id']: row for row in rows}
+    violations = []
+    for row in rows:
+        row_pos = epic_pos.get(row.get('epic_id'))
+        if row_pos is None:
+            continue
+        for dep_id in (row.get('dep_ids') or []):
+            dep = by_id.get(dep_id)
+            if dep is None:
+                continue
+            dep_pos = epic_pos.get(dep.get('epic_id'))
+            if dep_pos is None or dep_pos <= row_pos:
+                continue
+            violations.append({
+                'invariant': 'serial-deadlock',
+                'step_ids': [row['id'], dep_id],
+                'message': (
+                    f"step {row['id']} (epic turn {row_pos}) depends on step "
+                    f"{dep_id} (epic turn {dep_pos}) — a BACKWARD cross-epic "
+                    "edge under serial execution. That dependency can never "
+                    "be released: its epic never goes live while this one, "
+                    "blocked on it, never closes. The gate can never open — "
+                    "this is a deadlock, not a stall. Re-order the epics, "
+                    "move both steps into one epic, or drop the edge."),
+            })
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# Requirement counts (item 2)
+# ---------------------------------------------------------------------------
+
+def requirement_counts(model):
+    """Met/total requirement counts, per epic and for the whole plan —
+    RE-POINTED at the step's `epic_fk` (item 2): a requirement's bucket is
+    now where its work is SEATED, not where its (nonexistent) feature was
+    filed. `pipeline2_step_requirements` carries `PRIMARY KEY
+    (requirement_fk)` alone (gate delta, req #3336) — one step per
+    requirement, structural — so the lookup is a plain one-to-one join, not a
+    tie-break.
+
+    Tracking requirements are excluded from both the numerator and the
+    denominator, unchanged from 1.0 (req #3123's container exemption). The
+    numerator is `TERMINAL_REQUIREMENT_STATUSES`, matching the state machine
+    a step's own `done` derivation already uses.
+
+    `by_epic` is a LIST, sorted by epic id ascending — matching 1.0's reason
+    for the same shape: a Python dict with int keys silently stringifies
+    under `json.dumps`, which would make this module's wire shape disagree
+    with any 2.0 counterpart that renders a JS `Map` (not JSON at all) the
+    same way. See the module docstring for the measured before/after delta
+    on the live plan.
+
+    **`overall`'s POPULATION follows `model['requirements']`, which is a
+    different set depending on which composed read produced `model`** — the
+    same "which population" caveat `get_pipeline2_epic_composed`'s own
+    docstring states for `step_count` (req #3287). On the whole-plan read
+    it is every requirement in the plan; on the epic-scoped read it is only
+    the requirements linked to THAT epic's own steps, so `overall` there is
+    identical to that epic's own `by_epic` entry — never the plan's true
+    total. A caller rendering "N/M requirements complete" from an
+    epic-scoped read is showing the epic's number, not the plan's, and must
+    label it that way.
+    """
+    steps_by_id = _index_by_id(model.get('steps'))
+    req_to_step = {}
+    for link in model.get('step_requirements') or []:
+        req_to_step[link['requirement_fk']] = link['step_fk']
+
+    overall = {'met': 0, 'total': 0}
+    by_epic = {}
+    for req in model.get('requirements') or []:
+        if not req or is_tracking_requirement(req):
+            continue
+        met = req.get('requirement_status') in TERMINAL_REQUIREMENT_STATUSES
+        overall['total'] += 1
+        if met:
+            overall['met'] += 1
+        step = steps_by_id.get(req_to_step.get(req['id']))
+        epic_id = step.get('epic_fk') if step else None
+        if epic_id is None:
+            continue
+        bucket = by_epic.setdefault(epic_id, {'epic_id': epic_id, 'met': 0, 'total': 0})
+        bucket['total'] += 1
+        if met:
+            bucket['met'] += 1
+    return {
+        'overall': overall,
+        'by_epic': sorted(by_epic.values(), key=lambda b: _id_sort_key(b['epic_id'])),
+    }
+
+
+# ---------------------------------------------------------------------------
+# The whole derivation, in one call
+# ---------------------------------------------------------------------------
+
+def derive_plan2(model, now=None, epic_scoped=False):
+    """Everything this requirement derives from one composed 2.0 payload:
+    derive -> order -> check. Pure CPU over rows the composed read already
+    fetched — zero additional gateway reads, matching design rule 5.
+
+    Narrower than `pipeline_derive.derive_plan` in one respect: no batches —
+    Batch does not exist in 2.0. `eligible`, `pause` AND `serial` ARE built
+    here (DRV-005/006/016/017/018 for the first two — the verification
+    register's boundary, not req #3345's stale docstring; `serial` per the
+    gate delta naming req #3388 explicitly, which the register does not
+    cover at all — see the module docstring's Scope section). `now` rides
+    the payload for the same reason 1.0 carries it, and because
+    `eligibility` above is one of this module's own consumers of it.
+
+    `epic_scoped` MUST be `True` when `model` came from
+    `get_pipeline2_epic_composed` — it changes only how `verify_order`
+    reports a dependency it cannot see (an honest `out_of_scope_dep_ids`
+    entry instead of a false `dangling-dependency` alarm; see that
+    function's docstring for the defect this fixes). It does not change
+    ordering or eligibility: a step gated on an out-of-scope dependency is
+    correctly, and unavoidably, `eligible: False` here either way — this
+    payload cannot see whether that dependency is done, and the safe
+    direction is not to guess. A caller that needs the true answer reads the
+    whole-plan render instead.
+
+    Every per-row field here is an id, an enum string, a boolean, or a short
+    list of one of those — no re-embedded requirement or epic rows, matching
+    1.0's "compact block" discipline (`test_the_derived_block_is_compact_
+    ids_and_enums_only`'s reason, req #3078's payload budget).
+    """
+    if now is None:
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+
+    plan_rows = build_plan_rows(model)
+    ordered = display_order(plan_rows, model.get('epics') or [])
+    rows = ordered['rows']
+    violations, out_of_scope_dep_ids = verify_order(rows, epic_scoped=epic_scoped)
+    # AFTER `display_order`, so `suppressed_step_ids` comes out in display
+    # order, and it writes `launch_suppressed`/`suppressed_by` onto the same
+    # row dicts the payload below projects — matching 1.0's ordering of the
+    # two calls and its stated reason.
+    pause = pause_state(model, rows)
+    # AFTER `pause_state`, because it APPENDS to the `suppressed_by` list
+    # that call creates rather than replacing it — a step held by both a
+    # pause and a turn must name both (matches 1.0's ordering, req #3388).
+    serial = serial_state(model, rows, ordered['epic_order'])
+    violations = violations + serial_deadlocks(rows, ordered['epic_order'], serial['serial'])
+
+    by_id = {row['id']: row for row in rows}
+    eligible_ids = [row['id'] for row in rows if eligibility(row, by_id, now)]
+    eligible_set = set(eligible_ids)
+    out_of_scope_set = set(out_of_scope_dep_ids)
+
+    unresolved = []
+    for row in rows:
+        for rid in row.get('unresolved_req_ids') or []:
+            if rid not in unresolved:
+                unresolved.append(rid)
+
+    return {
+        'now': (now.isoformat(timespec='seconds') + 'Z'
+                if isinstance(now, datetime) else now),
+        'epic_order': ordered['epic_order'],
+        'display_order': [row['id'] for row in rows],
+        'rows': [{
+            'id': row['id'],
+            'state': row['state'],
+            'run': row['run'],
+            'eligible': row['id'] in eligible_set,
+            'epic_id': row['epic_id'],
+            'dep_ids': row['dep_ids'],
+            # Which of THIS row's own deps are out of scope (a subset of
+            # `dep_ids`, always empty unless `epic_scoped`) — so a reader
+            # deciding why a row is `eligible: False` does not have to
+            # intersect `dep_ids` against the plan-level
+            # `out_of_scope_dep_ids` by hand to find the honest reason.
+            'out_of_scope_dep_ids': [d for d in row['dep_ids'] if d in out_of_scope_set],
+            'req_ids': row['req_ids'],
+            'tracking_req_ids': row['tracking_req_ids'],
+            'unresolved_req_ids': row['unresolved_req_ids'],
+            'launch_req_ids': row['launch_req_ids'],
+            'launch_excluded': row['launch_excluded'],
+            'launch_block': row['launch_block'],
+            'swarm_start_command': row['swarm_start_command'],
+            'no_launch_reason': row['no_launch_reason'],
+            'launch_suppressed': row['launch_suppressed'],
+            'suppressed_by': row['suppressed_by'],
+        } for row in rows],
+        'pause': pause,
+        'serial': serial,
+        'eligible_step_ids': eligible_ids,
+        'violations': violations,
+        'cycle_detected': ordered['cycle_detected'],
+        'cycle_step_ids': ordered['cycle_step_ids'],
+        'duplicate_step_ids': ordered['duplicate_step_ids'],
+        'unresolved_req_ids': unresolved,
+        # Only ever non-empty when `epic_scoped=True` — a dependency this
+        # epic-scoped payload never fetched, not a plan defect. See
+        # `verify_order`'s docstring.
+        'out_of_scope_dep_ids': out_of_scope_dep_ids,
+        'requirement_counts': requirement_counts(model),
+    }

--- a/tests/test_pipeline2_compose.py
+++ b/tests/test_pipeline2_compose.py
@@ -1,0 +1,343 @@
+"""The Pipeline 2.0 composing route — integration tier (req #3367).
+
+`GET /darwin_dev/pipeline2_compose?id=<pipeline_id>` and
+`GET /darwin_dev/pipeline2_compose_epic?id=<epic_id>` — the ONE non-generic
+route this requirement adds. Everything here is driven through
+`lambda_handler` exactly like the generic gateway's own tests, proving the
+route end to end: auth, scoping, shape, derivation, and the budget ladder.
+
+The plan/epic/step fixtures are built through the REAL gateway (POST to the
+generic `pipeline2_*` table routes) rather than raw SQL — same discipline as
+`test_junction_scoping.py`: it is simultaneously the regression guard that an
+owner can still create this graph at all.
+
+Needs `darwin_dev` (`. exports.sh`); skips cleanly without it (via the
+`invoke`/`db_connection` fixtures).
+"""
+import json
+import time
+import uuid
+
+import pytest
+
+from conftest import extract_id
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def owner_fk():
+    return f"p2compose-owner-{int(time.time())}-{uuid.uuid4().hex[:6]}"
+
+
+@pytest.fixture(scope="module")
+def other_fk():
+    return f"p2compose-other-{int(time.time())}-{uuid.uuid4().hex[:6]}"
+
+
+def _invoker(sub):
+    from handler import lambda_handler
+
+    def _invoke(method, path, query=None, body=None):
+        return lambda_handler({
+            'httpMethod': method,
+            'path': path,
+            'queryStringParameters': query,
+            'body': json.dumps(body) if body is not None else None,
+            'requestContext': {'authorizer': {'claims': {'sub': sub}}},
+        }, {})
+    return _invoke
+
+
+def _purge(conn, creator):
+    import pymysql as _pymysql
+    try:
+        with conn.cursor() as cur:
+            cur.execute("DELETE FROM pipeline2_step_deps WHERE step_fk IN "
+                        "(SELECT id FROM pipeline2_steps WHERE creator_fk = %s)", (creator,))
+            cur.execute("DELETE FROM pipeline2_step_requirements WHERE step_fk IN "
+                        "(SELECT id FROM pipeline2_steps WHERE creator_fk = %s)", (creator,))
+            cur.execute("DELETE FROM pipeline2_steps WHERE creator_fk = %s", (creator,))
+            cur.execute("DELETE FROM pipeline2_epics WHERE creator_fk = %s", (creator,))
+            cur.execute("DELETE FROM pipeline2_pipelines WHERE creator_fk = %s", (creator,))
+            cur.execute("DELETE FROM requirements WHERE creator_fk = %s", (creator,))
+            cur.execute("DELETE FROM categories WHERE creator_fk = %s", (creator,))
+            cur.execute("DELETE FROM projects WHERE creator_fk = %s", (creator,))
+            cur.execute("DELETE FROM profiles WHERE id = %s", (creator,))
+        conn.commit()
+    except _pymysql.MySQLError:
+        conn.rollback()
+
+
+@pytest.fixture(scope="module")
+def owner(owner_fk, db_connection):
+    invoke = _invoker(owner_fk)
+    invoke('POST', '/darwin_dev/profiles', body={
+        'id': owner_fk, 'name': 'p2compose owner', 'email': 'p2c-owner@test.invalid'})
+    yield invoke
+    _purge(db_connection, owner_fk)
+
+
+@pytest.fixture(scope="module")
+def other(other_fk, db_connection):
+    invoke = _invoker(other_fk)
+    invoke('POST', '/darwin_dev/profiles', body={
+        'id': other_fk, 'name': 'p2compose other', 'email': 'p2c-other@test.invalid'})
+    yield invoke
+    _purge(db_connection, other_fk)
+
+
+@pytest.fixture(scope="module")
+def plan(owner):
+    """One pipeline, one epic, two requirement-backed steps, one gate step
+    depending on both — mirrors the darwin-mcp unit fixture's shape."""
+    ids = {}
+
+    resp = owner('POST', '/darwin_dev/projects', body={'project_name': 'p2compose project'})
+    assert resp['statusCode'] == 200, resp
+    ids['project'] = int(extract_id(resp))
+
+    resp = owner('POST', '/darwin_dev/categories',
+                body={'category_name': 'p2compose category', 'project_fk': ids['project']})
+    assert resp['statusCode'] == 200, resp
+    ids['category'] = int(extract_id(resp))
+
+    resp = owner('POST', '/darwin_dev/pipeline2_pipelines', body={
+        'title': 'p2compose plan', 'description': 'the goal',
+        'pipeline_status': 'active', 'execution_mode': 'parallel'})
+    assert resp['statusCode'] == 200, resp
+    ids['pipeline'] = int(extract_id(resp))
+
+    resp = owner('POST', '/darwin_dev/pipeline2_epics', body={
+        'pipeline_fk': ids['pipeline'], 'title': 'p2compose epic',
+        'description': 'build it', 'epic_status': 'active',
+        'category_fk': ids['category'], 'sort_order': 'NULL', 'closed': '0'})
+    assert resp['statusCode'] == 200, resp
+    ids['epic'] = int(extract_id(resp))
+
+    for key, title, status in (('req_a', 'requirement A', 'development'),
+                               ('req_b', 'requirement B', 'authoring')):
+        resp = owner('POST', '/darwin_dev/requirements', body={
+            'title': title, 'requirement_status': status,
+            'category_fk': ids['category'], 'coordination_type': 'deployed',
+            'ai_model': 'sonnet', 'effort': 'high'})
+        assert resp['statusCode'] == 200, resp
+        ids[key] = int(extract_id(resp))
+
+    for key, title, run in (('step_a', 'read service', 'auto'),
+                            ('step_b', 'tools', 'auto'),
+                            ('step_gate', 'gate', 'manual')):
+        resp = owner('POST', '/darwin_dev/pipeline2_steps', body={
+            'epic_fk': ids['epic'], 'title': title, 'run': run})
+        assert resp['statusCode'] == 200, resp
+        ids[key] = int(extract_id(resp))
+
+    resp = owner('POST', '/darwin_dev/pipeline2_step_requirements',
+                body={'step_fk': ids['step_a'], 'requirement_fk': ids['req_a']})
+    assert resp['statusCode'] in (200, 201), resp
+    resp = owner('POST', '/darwin_dev/pipeline2_step_requirements',
+                body={'step_fk': ids['step_b'], 'requirement_fk': ids['req_b']})
+    assert resp['statusCode'] in (200, 201), resp
+
+    for dep in (ids['step_a'], ids['step_b']):
+        resp = owner('POST', '/darwin_dev/pipeline2_step_deps',
+                    body={'step_fk': ids['step_gate'], 'dep_step_fk': dep})
+        assert resp['statusCode'] == 200, resp
+
+    return ids
+
+
+# ---------------------------------------------------------------------------
+# Shape and content
+# ---------------------------------------------------------------------------
+
+def _get(invoke, table, row_id):
+    return invoke('GET', f'/darwin_dev/{table}', query={'id': str(row_id)})
+
+
+class TestWholePlanCompose:
+    def test_carries_the_whole_plan(self, owner, plan):
+        resp = _get(owner, 'pipeline2_compose', plan['pipeline'])
+        assert resp['statusCode'] == 200, resp
+        body = json.loads(resp['body'])
+
+        assert set(body) == {'pipeline', 'epics', 'steps', 'step_requirements',
+                             'step_deps', 'requirements', 'derived'}
+        assert body['pipeline']['title'] == 'p2compose plan'
+        assert body['pipeline']['step_count'] == 3
+        assert [s['title'] for s in body['steps']] == ['read service', 'tools', 'gate']
+        assert len(body['step_requirements']) == 2
+        assert len(body['step_deps']) == 2
+        assert sorted(r['id'] for r in body['requirements']) == sorted(
+            [plan['req_a'], plan['req_b']])
+
+        assert len(body['epics']) == 1
+        epic = body['epics'][0]
+        assert set(epic) == {'id', 'pipeline_fk', 'title', 'description',
+                             'epic_status', 'sort_order', 'category_fk', 'closed'}
+        assert epic['description'] == 'build it'
+
+    def test_requirements_are_the_light_projection(self, owner, plan):
+        resp = _get(owner, 'pipeline2_compose', plan['pipeline'])
+        body = json.loads(resp['body'])
+        for row in body['requirements']:
+            assert set(row) == {'id', 'title', 'requirement_status', 'coordination_type',
+                                'ai_model', 'effort', 'machine_fk', 'tracking'}
+            assert 'description' not in row
+            assert 'feature_fk' not in row
+
+    def test_steps_have_no_state_column_and_epic_fk_not_pipeline_fk(self, owner, plan):
+        resp = _get(owner, 'pipeline2_compose', plan['pipeline'])
+        body = json.loads(resp['body'])
+        for step in body['steps']:
+            assert 'state' not in step and 'status' not in step
+            assert 'pipeline_fk' not in step
+            assert step['epic_fk'] == plan['epic']
+
+    def test_derived_is_a_real_answer(self, owner, plan):
+        resp = _get(owner, 'pipeline2_compose', plan['pipeline'])
+        body = json.loads(resp['body'])
+        derived = body['derived']
+        assert 'withheld' not in derived
+        assert derived['display_order'] == [plan['step_a'], plan['step_b'], plan['step_gate']]
+        by_id = {row['id']: row['state'] for row in derived['rows']}
+        # req_a is `development` -> its step is running; req_b is `authoring`
+        # -> pending; the gate waits on both -> pending.
+        assert by_id[plan['step_a']] == 'running'
+        assert by_id[plan['step_b']] == 'pending'
+        assert by_id[plan['step_gate']] == 'pending'
+
+    def test_missing_pipeline_is_404(self, owner):
+        resp = _get(owner, 'pipeline2_compose', 999999999)
+        assert resp['statusCode'] == 404, resp
+        assert resp['body'] == '"NOT FOUND"'
+
+    def test_browser_and_daemon_receive_byte_identical_derived_blocks(self, owner, plan):
+        """req #3367's acceptance criterion, literally: 'a test proves the
+        browser and the daemon receive byte-identical derived blocks for the
+        same plan.' There is only one producer now — this route — so a
+        'browser read' and a 'daemon passthrough read' are the same HTTP call
+        made twice. That is not a tautology to wave through: before this
+        requirement there were two DIFFERENT producers (`pipelineModel.js` in
+        the browser, `pipeline2_derive.py` in the daemon) that COULD disagree,
+        and the corpus existed to catch it when they did. Proving two calls
+        to the one remaining producer return identical bytes is what "one
+        derivation, in one place" cashes out to once B is chosen."""
+        first = _get(owner, 'pipeline2_compose', plan['pipeline'])
+        second = _get(owner, 'pipeline2_compose', plan['pipeline'])
+        assert first['body'] == second['body']
+        assert json.loads(first['body'])['derived'] == json.loads(second['body'])['derived']
+
+
+class TestEpicScopedCompose:
+    def test_carries_one_epic(self, owner, plan):
+        resp = _get(owner, 'pipeline2_compose_epic', plan['epic'])
+        assert resp['statusCode'] == 200, resp
+        body = json.loads(resp['body'])
+        assert len(body['epics']) == 1
+        assert body['epics'][0]['id'] == plan['epic']
+        assert body['epics'][0]['step_count'] == 3
+        assert body['pipeline']['id'] == plan['pipeline']
+
+    def test_missing_epic_is_404(self, owner):
+        resp = _get(owner, 'pipeline2_compose_epic', 999999999)
+        assert resp['statusCode'] == 404, resp
+
+
+# ---------------------------------------------------------------------------
+# Cross-tenant scoping (req #3122/#3125's discipline applied to this route)
+# ---------------------------------------------------------------------------
+
+class TestScoping:
+    def test_unauthenticated_is_403(self, plan):
+        from handler import lambda_handler
+        resp = lambda_handler({
+            'httpMethod': 'GET', 'path': '/darwin_dev/pipeline2_compose',
+            'queryStringParameters': {'id': str(plan['pipeline'])},
+            'body': None, 'requestContext': {},
+        }, {})
+        assert resp['statusCode'] == 403, resp
+        assert resp['body'] == '"FORBIDDEN"'
+
+    def test_another_creator_cannot_read_the_plan(self, other, plan):
+        resp = _get(other, 'pipeline2_compose', plan['pipeline'])
+        assert resp['statusCode'] == 404, resp
+
+    def test_another_creator_cannot_read_the_epic(self, other, plan):
+        resp = _get(other, 'pipeline2_compose_epic', plan['epic'])
+        assert resp['statusCode'] == 404, resp
+
+    def test_missing_id_is_400(self, owner):
+        resp = owner('GET', '/darwin_dev/pipeline2_compose', query=None)
+        assert resp['statusCode'] == 400, resp
+
+    def test_non_get_is_400(self, owner, plan):
+        resp = owner('POST', '/darwin_dev/pipeline2_compose', body={'id': plan['pipeline']})
+        assert resp['statusCode'] == 400, resp
+
+
+# ---------------------------------------------------------------------------
+# Epic-scoped derivation nuance: a cross-epic dependency is reported
+# differently depending on which route answers (req #3345/#3349's own tested
+# behaviour — carried over verbatim now that Lambda-Rest is the one place it
+# runs).
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def two_epic_plan(owner):
+    ids = {}
+    resp = owner('POST', '/darwin_dev/projects', body={'project_name': 'p2compose 2-epic project'})
+    ids['project'] = int(extract_id(resp))
+    resp = owner('POST', '/darwin_dev/categories',
+                body={'category_name': 'p2compose 2-epic category', 'project_fk': ids['project']})
+    ids['category'] = int(extract_id(resp))
+
+    resp = owner('POST', '/darwin_dev/pipeline2_pipelines', body={
+        'title': 'p2compose two epics', 'pipeline_status': 'active',
+        'execution_mode': 'parallel'})
+    ids['pipeline'] = int(extract_id(resp))
+
+    for key, title, order in (('epic_a', 'epic A', '1'), ('epic_b', 'epic B', '2')):
+        resp = owner('POST', '/darwin_dev/pipeline2_epics', body={
+            'pipeline_fk': ids['pipeline'], 'title': title, 'epic_status': 'active',
+            'category_fk': ids['category'], 'sort_order': order, 'closed': '0'})
+        assert resp['statusCode'] == 200, resp
+        ids[key] = int(extract_id(resp))
+
+    resp = owner('POST', '/darwin_dev/pipeline2_steps',
+                body={'epic_fk': ids['epic_a'], 'title': 'A step', 'run': 'auto',
+                      'completed_at': '2026-08-01 00:00:00'})
+    ids['step_a'] = int(extract_id(resp))
+    resp = owner('POST', '/darwin_dev/pipeline2_steps',
+                body={'epic_fk': ids['epic_b'], 'title': 'B step', 'run': 'auto'})
+    ids['step_b'] = int(extract_id(resp))
+
+    resp = owner('POST', '/darwin_dev/requirements', body={
+        'title': 'two-epic requirement', 'requirement_status': 'authoring',
+        'category_fk': ids['category'], 'coordination_type': 'deployed',
+        'ai_model': 'sonnet', 'effort': 'high'})
+    ids['req'] = int(extract_id(resp))
+    owner('POST', '/darwin_dev/pipeline2_step_requirements',
+         body={'step_fk': ids['step_b'], 'requirement_fk': ids['req']})
+    owner('POST', '/darwin_dev/pipeline2_step_deps',
+         body={'step_fk': ids['step_b'], 'dep_step_fk': ids['step_a']})
+    return ids
+
+
+def test_epic_scoped_reports_out_of_scope_never_dangling(owner, two_epic_plan):
+    resp = _get(owner, 'pipeline2_compose_epic', two_epic_plan['epic_b'])
+    body = json.loads(resp['body'])
+    derived = body['derived']
+    assert derived['out_of_scope_dep_ids'] == [two_epic_plan['step_a']]
+    assert [v for v in derived['violations'] if v['invariant'] == 'dangling-dependency'] == []
+
+
+def test_whole_plan_sees_the_same_edge_as_an_ordinary_satisfied_gate(owner, two_epic_plan):
+    resp = _get(owner, 'pipeline2_compose', two_epic_plan['pipeline'])
+    body = json.loads(resp['body'])
+    derived = body['derived']
+    assert derived['out_of_scope_dep_ids'] == []
+    assert derived['violations'] == []
+    assert two_epic_plan['step_b'] in derived['eligible_step_ids']

--- a/tests/test_pipeline2_compose_budget.py
+++ b/tests/test_pipeline2_compose_budget.py
@@ -1,0 +1,142 @@
+"""The Pipeline 2.0 composing route's budget ladder — unit tier (req #3367).
+
+Pure-function tests, no database: `pipeline2_compose._bounded` is the ONE
+place this now runs (moved from darwin-mcp's `server._bounded_plan2`, which
+this route obsoletes — the daemon no longer bounds anything, because what it
+receives from here is already bounded). Byte-identical algorithm; these tests
+mirror darwin-mcp's `tests/unit/test_pipelines2.py` budget-ladder section so
+the same three regimes stay provably covered after the move.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+import pipeline2_compose as pc                          # noqa: E402
+
+
+def _fake_composed(step_count=3, notes_len=10, derived_bytes=200):
+    steps = [{'id': i, 'epic_fk': 1, 'title': f's{i}', 'run': 'auto',
+             'not_before': None, 'notes': 'x' * notes_len,
+             'completed_at': None} for i in range(1, step_count + 1)]
+    return {
+        'pipeline': {'id': 1, 'title': 'p', 'step_count': step_count},
+        'epics': [{'id': 1, 'pipeline_fk': 1, 'title': 'e'}],
+        'steps': steps,
+        'step_requirements': [],
+        'step_deps': [],
+        'requirements': [],
+        'derived': {'withheld': True, 'reason': 'x' * derived_bytes,
+                   'withheld_reason': 'derivation_failed', 'rows_complete': True},
+    }
+
+
+def _bounded(composed, budget, monkeypatch, **kwargs):
+    monkeypatch.setattr(pc, 'PAYLOAD_BUDGET_BYTES', budget)
+    return pc._bounded('pipeline2_compose/1', composed, **kwargs)
+
+
+def test_a_plan_under_budget_ships_regime_a_unchanged(monkeypatch):
+    composed = _fake_composed()
+    result = _bounded(composed, 1_000_000, monkeypatch)
+    assert result is composed
+    assert result['derived']['withheld_reason'] == 'derivation_failed'
+
+
+def test_an_empty_plan_is_never_bounded(monkeypatch):
+    composed = _fake_composed(step_count=0)
+    result = _bounded(composed, 1, monkeypatch)
+    assert result is composed
+
+
+def test_regime_b_withholds_derived_and_keeps_every_row(monkeypatch):
+    """A LARGE `derived` block pushes the payload over budget on its own;
+    withholding it alone is enough."""
+    composed = _fake_composed(step_count=5, notes_len=20, derived_bytes=50_000)
+    budget = pc.payload_bytes(composed) - 1
+    assert budget < pc.payload_bytes(composed)
+
+    result = _bounded(composed, budget, monkeypatch)
+
+    assert len(result['steps']) == 5
+    assert not any(pc.TRUNCATION_KEY in s for s in result['steps'])
+    assert pc.TRUNCATION_KEY not in result
+    assert result['derived']['withheld_reason'] == pc.WITHHELD_BUDGET_DERIVED_ONLY
+    assert result['derived']['rows_complete'] is True
+    # THE OVER-BUDGET TRAP: the naive "swap stub in, then measure" fix ships
+    # over budget because it forgets to re-check. Assert the shipped payload
+    # actually fits.
+    assert pc.payload_bytes(result) <= budget
+
+
+def test_regime_c_truncates_steps_and_prunes_dependents(monkeypatch):
+    composed = _fake_composed(step_count=50, notes_len=2000, derived_bytes=50_000)
+    composed['step_requirements'] = [
+        {'step_fk': i, 'requirement_fk': 100 + i} for i in range(1, 51)]
+    composed['step_deps'] = [
+        {'step_fk': i, 'dep_step_fk': i - 1} for i in range(2, 51)]
+
+    budget = 10_000
+    result = _bounded(composed, budget, monkeypatch)
+
+    assert pc.TRUNCATION_KEY in result
+    kept = {s['id'] for s in result['steps'] if pc.TRUNCATION_KEY not in s}
+    assert 0 < len(kept) < 50, 'the budget must actually bite for this test to mean anything'
+    for row in result['step_requirements']:
+        assert row['step_fk'] in kept
+    for row in result['step_deps']:
+        assert row['step_fk'] in kept and row['dep_step_fk'] in kept
+
+    assert result['derived']['withheld_reason'] == pc.WITHHELD_BUDGET_ROWS_TRUNCATED
+    assert result['derived']['rows_complete'] is False
+    assert result['pipeline']['step_count'] == 50
+    assert pc.payload_bytes(result) <= budget
+
+
+def test_regime_c_never_ships_over_budget_across_a_sweep(monkeypatch):
+    """`remaining` (the allowance regime C's own truncation pass gets) must be
+    measured against the REGIME-C `derived` stub that actually ships, never
+    against regime B's — the two messages are different lengths with no
+    reason to stay in a particular order, and measuring the wrong one is a
+    latent over-budget bug that only shows up once someone edits either
+    message's wording (found in review, req #3367)."""
+    for step_count in (1, 4, 7, 13, 25, 40):
+        for notes_len in (0, 50, 500, 2000):
+            for derived_bytes in (0, 1000, 20_000, 80_000):
+                for budget in (5_000, 8_000, 10_000, 20_000):
+                    composed = _fake_composed(step_count=step_count, notes_len=notes_len,
+                                              derived_bytes=derived_bytes)
+                    composed['step_requirements'] = [
+                        {'step_fk': i, 'requirement_fk': 100 + i}
+                        for i in range(1, step_count + 1)]
+                    composed['step_deps'] = [
+                        {'step_fk': i, 'dep_step_fk': i - 1}
+                        for i in range(2, step_count + 1)]
+                    result = _bounded(composed, budget, monkeypatch)
+                    size = pc.payload_bytes(result)
+                    assert size <= budget, (
+                        f"over budget by {size - budget}B: step_count={step_count} "
+                        f"notes_len={notes_len} derived_bytes={derived_bytes} "
+                        f"budget={budget}")
+
+
+def test_regime_c_never_ships_the_real_derived_block(monkeypatch):
+    composed = _fake_composed(step_count=40, notes_len=1500, derived_bytes=80_000)
+    result = _bounded(composed, 8_000, monkeypatch)
+    assert result['derived'] != composed['derived']
+    assert result['derived']['withheld'] is True
+
+
+def test_deriver_exception_degrades_to_a_withheld_stub_without_losing_rows(monkeypatch):
+    """`_derive`'s guard: a `derive_plan2` exception must never take the real
+    rows down with it."""
+    def boom(model, now=None, epic_scoped=False):
+        raise RuntimeError('synthetic failure')
+
+    monkeypatch.setattr(pc.pipeline2_derive, 'derive_plan2', boom)
+    model = {'pipeline': {'id': 1}, 'epics': [], 'steps': [],
+             'step_requirements': [], 'step_deps': [], 'requirements': []}
+    derived = pc._derive(model)
+    assert derived['withheld'] is True
+    assert derived['withheld_reason'] == pc.WITHHELD_DERIVATION_FAILED
+    assert derived['rows_complete'] is True

--- a/tests/test_pipeline2_derive.py
+++ b/tests/test_pipeline2_derive.py
@@ -1,0 +1,992 @@
+"""Pipeline 2.0 derivation — the unit tier (req #3349; MOVED HERE by req #3367
+along with the module itself — `memory/pipeline-2-orchestration-algorithm.md`
+§ 8, remediation B composing form).
+
+Pure-function tests: `pipeline2_derive.py` performs no I/O, so unlike
+`test_pipeline2_compose.py` there is no fake gateway here — every test builds
+a composed-read-shaped `model` dict directly (`{pipeline, epics, steps,
+step_requirements, step_deps, requirements}`) and calls the module's
+functions against it. No database, no `exports.sh` needed.
+
+Two things this tier is uniquely able to prove:
+
+  * **A deleted field never reappears.** A field that silently survives on a
+    derived row is req #3349's own stated failure mode — see the
+    "deleted fields" block below.
+  * **The epic-scoped state-banding self-check**, including the amended
+    three-step case (`memory/pipeline-2-visualizer-design.md` § 5.3) that a
+    global-vs-scoped confusion would otherwise hide.
+
+## The corpus, re-pointed at one target (req #3367 deliverable 6)
+
+`darwin-mcp/tests/conformance/pipeline_conformance.json` (52 cases, checked
+2026-08-09 — the "34" some earlier prose cites is stale) is 1.0's drift
+control between two implementations. Under remediation B there is only ONE
+2.0 implementation and there has never been a second — `pipelineModel.js` has
+no 2.0 counterpart and, per this module's own docstring item 5, never will —
+so re-pointing the corpus "at one target" means what it says: every case
+whose BEHAVIOUR still exists in 2.0 is re-expressed as a test THIS FILE runs
+against `derive_plan2` directly, and "retire the second harness" is satisfied
+by there being nothing to retire (no `test_pipeline2_model.test.js` was ever
+built). The 1.0 corpus file and its two harnesses are UNTOUCHED — 1.0 keeps
+operating and its own drift control stays exactly as it was.
+
+**Mapping, by 1.0 case name.** Cases are grouped by what they test, not by
+file order, so the N/A reasons read as one structural argument rather than 52
+one-line verdicts.
+
+Translated and covered by a test in this file:
+  `empty-plan` → `test_empty_plan_derives_cleanly`;
+  `single-step-linkless-unstamped`, `single-step-linkless-stamped`,
+    `rule1-terminal-status-matrix` →
+    `test_derive_step_state_done_running_pending`,
+    `test_derive_step_state_with_no_gating_requirements_reads_completed_at`,
+    `test_all_container_links_derive_from_completion_stamp_never_running`;
+  `tracking-container-exemption` → `test_tracking_requirement_never_gates`,
+    `test_all_container_links_derive_from_completion_stamp_never_running`;
+  `tracking-flag-coercion` → `test_tracking_flag_coercion_matrix`;
+  `requirement-counts-tracking-and-terminal-statuses`,
+    `requirement-counts-deferred-completes-epic`,
+    `requirement-counts-wontfix-completes-epic` →
+    `test_requirement_counts_groups_by_the_seated_epic_not_a_feature_chain`,
+    `test_requirement_counts_excludes_tracking_containers`,
+    `test_requirement_with_no_step_link_counts_overall_not_by_epic`
+    (`met`/`deferred`/`wontfix` are one TERMINAL_REQUIREMENT_STATUSES tuple,
+    not three branches — a case per status is not a case per behaviour);
+  `eligibility-step-gates`, `eligibility-time-gate-passed`,
+    `eligibility-time-gate-pending`, `time-gate-timestamp-formats`,
+    `time-gate-with-no-clock`, `time-gate-non-canonical-spellings-are-not-passed` →
+    `test_eligibility_requires_every_dependency_done`,
+    `test_eligibility_consults_not_before_against_the_payload_clock`,
+    `test_eligibility_is_false_for_a_non_pending_row` (the timestamp-grammar
+    hazards themselves are `_to_epoch`'s, restated verbatim from 1.0's
+    already-tested `_TIMESTAMP_RE` — module docstring "changed" item 3);
+  `topological-order-diamond`, `state-bands-outrank-stored-order`,
+    `banding-inversion-forced-by-topology-is-not-a-violation` →
+    `test_three_step_single_epic_case_still_reports_amended_acceptance` and
+    the `display_order`/`verify_order` tests around it;
+  `cycle-detection` → `test_cycle_within_one_epic_is_detected_and_falls_back_to_stored_order`;
+  `duplicate-step-ids` → `test_duplicate_step_id_is_reported`;
+  `dangling-dependency` →
+    `test_dangling_dependency_is_detected_and_reported`,
+    `test_epic_scoped_read_reports_out_of_scope_not_dangling`,
+    `test_whole_plan_read_still_reports_a_genuinely_dangling_dependency`;
+  `unresolved-requirement-ids` →
+    `test_derive_plan2_unresolved_requirement_is_reported_not_silently_dropped`;
+  `pause-suppresses-whole-plan`, `pause-suppresses-one-epic-not-its-neighbour` →
+    `test_epic_pause_suppresses_only_that_epics_steps`,
+    `test_whole_plan_pause_suppresses_every_epics_steps`,
+    `test_suppressed_by_names_both_reasons_when_both_fire`;
+  `serial-holds-every-epic-but-the-live-one`,
+    `serial-advances-when-the-live-epic-closes`,
+    `serial-terminal-statuses-close-an-epic-like-met`,
+    `serial-and-pause-both-name-themselves`,
+    `serial-never-holds-a-step-with-no-epic-label` (N/A half: no step can
+    have no epic label — folds into the epic_fk-is-a-column argument below),
+    `serial-all-epics-closed-holds-nothing`,
+    `parallel-is-the-default-and-suppresses-nothing`,
+    `absent-execution-mode-reads-as-parallel` → the whole serial-state block,
+    `test_serial_state_parallel_mode_holds_nothing` through
+    `test_backward_edge_under_parallel_mode_is_not_a_deadlock`;
+  `launchable-status-matrix`, `launch-args-drop-met-requirements`,
+    `unresolved-requirement-is-not-launchable` (their PER-STEP half; the
+    BATCH half is N/A below) →
+    `test_launch_req_ids_only_swarm_ready_minus_containers`,
+    `test_no_launch_reason_distinguishes_no_links_from_containers`;
+  `epic-sort-order-outranks-first-appearance`,
+    `epic-sort-order-absent-falls-back-to-first-appearance`,
+    `epic-sort-order-null-sorts-after-every-ordered-epic` →
+    `test_manual_sort_order_orders_the_epic_blocks`,
+    `test_manual_sort_order_wins_over_derived_order`,
+    `test_started_epics_order_by_earliest_activity_ahead_of_unstarted`;
+  `serial-turn-follows-the-epic-sort-order` → `test_turn_suppression_appends_to_pause_suppression`
+    plus the sort-order tests above (both mechanisms read the same `epic_order`);
+  `epic-sort-order-does-not-outrank-a-state-band` →
+    `test_epic_sort_order_does_not_outrank_a_within_epic_state_band`.
+
+Structurally N/A — the SCENARIO cannot occur in 2.0, not merely untested:
+  `batch-splits-on-machine`, `batch-splits-on-run-mode-and-gate`,
+    `batch-splits-on-epic`, `batch-groups-on-remaining-gate`,
+    `batch-no-launch-reason-no-links`, `batch-contiguity-avoidable-split-still-reports`,
+    `machines-sharing-a-title`, `batch-no-launch-reason-nothing-launchable`
+    (its batch half) — Batch does not exist in 2.0; the Step is the launch
+    unit (first-principles record § 6, docstring item 1's "no `batches` key");
+  `label-inheritance-chain`, `dominant-label-majority-and-tie`,
+    `epic-sort-order-rides-an-inherited-label` — `epic_fk` is a NOT NULL
+    column read directly; there is no tally, no majority vote, and no
+    inheritance walk to have a tie or a chain (docstring item 1);
+  `substrate-rebuild-34-rows` — a whole-plan integration fixture built from
+    1.0's batch+label machinery end to end; its individual RULES are each
+    covered above, and a 2.0-shaped equivalent integration case exists as
+    `Lambda-Rest/tests/test_pipeline2_compose.py`'s `plan` /
+    `two_epic_plan` fixtures, run against real `darwin_dev` rather than a
+    hand-built model.
+
+Verified rather than redone (module docstring item 6's own claim, checked
+against this mapping): every 1.0 case whose behaviour survives in 2.0 now has
+a 2.0-shaped test above it; three gaps the check surfaced —
+`test_empty_plan_derives_cleanly`, `test_tracking_flag_coercion_matrix`,
+`test_epic_sort_order_does_not_outrank_a_within_epic_state_band` — are added
+at the end of this file rather than left as a silent hole.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+import pipeline2_derive as deriv                        # noqa: E402
+
+_SUB = 'test-creator'
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — built by hand, not through a fake REST client
+# ---------------------------------------------------------------------------
+
+def _req(id, status='met', tracking=0, machine_fk=None):
+    return {'id': id, 'title': f'req {id}', 'requirement_status': status,
+            'coordination_type': 'deployed', 'ai_model': 'sonnet',
+            'effort': 'high', 'machine_fk': machine_fk, 'tracking': tracking}
+
+
+def _epic(id, pipeline_fk=900, sort_order=None, title=None):
+    return {'id': id, 'pipeline_fk': pipeline_fk, 'title': title or f'epic {id}',
+            'description': None, 'epic_status': 'active', 'category_fk': 1,
+            'sort_order': sort_order, 'closed': 0}
+
+
+def _step(id, epic_fk, title=None, run='auto', not_before=None, notes=None,
+         completed_at=None, create_ts='2026-08-01 00:00:00'):
+    return {'id': id, 'epic_fk': epic_fk, 'title': title or f'step {id}',
+            'run': run, 'not_before': not_before, 'notes': notes,
+            'completed_at': completed_at, 'creator_fk': _SUB,
+            'create_ts': create_ts, 'update_ts': create_ts}
+
+
+def _basic_model():
+    """One epic, three steps (two requirement-backed, one gate depending on
+    both) — the same shape as `test_pipelines2.py`'s `plan2` fixture."""
+    return {
+        'pipeline': {'id': 900, 'title': 'Pipeline 2.0 Build',
+                     'pipeline_status': 'active', 'execution_mode': 'parallel'},
+        'epics': [_epic(90)],
+        'steps': [
+            _step(9001, 90, title='read service'),
+            _step(9002, 90, title='tools'),
+            _step(9003, 90, title='gate', run='manual'),
+        ],
+        'step_requirements': [
+            {'step_fk': 9001, 'requirement_fk': 5010},
+            {'step_fk': 9002, 'requirement_fk': 5011},
+        ],
+        'step_deps': [
+            {'id': 1, 'step_fk': 9003, 'dep_step_fk': 9001},
+            {'id': 2, 'step_fk': 9003, 'dep_step_fk': 9002},
+        ],
+        'requirements': [_req(5010), _req(5011)],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Item 1 — epic_id is a column read; the deleted fields never appear
+# ---------------------------------------------------------------------------
+
+# COVERS: DRV-001
+def test_epic_id_is_read_from_the_step_column_no_tally_no_tiebreak():
+    model = _basic_model()
+    rows = deriv.build_plan_rows(model)
+    assert all(row['epic_id'] == 90 for row in rows)
+
+
+# COVERS: DRV-001, DRV-002
+def test_epic_id_follows_the_step_even_when_its_requirement_implies_nothing():
+    """A req-less gate step still carries its OWN epic_fk — there is no
+    inheritance walk to fall back on, because an unlabelled step cannot exist
+    once epic_fk is NOT NULL."""
+    model = _basic_model()
+    rows = {row['id']: row for row in deriv.build_plan_rows(model)}
+    assert rows[9003]['epic_id'] == 90
+
+
+# COVERS: DRV-002, DRV-003
+def test_deleted_fields_are_absent_from_every_derived_row():
+    """One test per deleted field (req #3349 item 6). A field that silently
+    survives is the failure this requirement exists to prevent."""
+    model = _basic_model()
+    plan = deriv.derive_plan2(model, now='2026-08-09T00:00:00Z')
+    deleted = ('inherited_labels', 'label_inherited', 'feature_id', 'feature',
+              'feature_labels', 'epic_labels', 'time_deps', 'epic',
+              'machine_fks')
+    for row in plan['rows']:
+        for field in deleted:
+            assert field not in row, f"{field} leaked onto a 2.0 derived row"
+    # And not on the internal build_plan_rows shape either, before projection.
+    for row in deriv.build_plan_rows(model):
+        for field in ('inherited_labels', 'label_inherited', 'feature_id',
+                      'feature', 'feature_labels', 'epic_labels', 'time_deps'):
+            assert field not in row, f"{field} leaked onto a build_plan_rows row"
+
+
+# COVERS: DRV-021
+def test_no_batches_key_but_pause_serial_and_eligibility_are_present():
+    """Batch does not exist in 2.0 (Step is the launch unit) — but `pause`,
+    `serial` and `eligible_step_ids` ARE this requirement's: the first two
+    per the verification register (DRV-005/006/016/017/018), `serial` per
+    req #3349's own gate delta naming req #3388 (the register has no DRV
+    entry for it at all, which is a gap in the register, not a scope
+    exclusion — see the module docstring)."""
+    model = _basic_model()
+    plan = deriv.derive_plan2(model, now='2026-08-09T00:00:00Z')
+    assert 'batches' not in plan
+    for key in ('pause', 'serial', 'eligible_step_ids'):
+        assert key in plan
+
+
+# ---------------------------------------------------------------------------
+# Item 2 — requirement_counts re-points at the step's seated epic
+# ---------------------------------------------------------------------------
+
+# COVERS: DRV-008
+def test_requirement_counts_groups_by_the_seated_epic_not_a_feature_chain():
+    model = {
+        'pipeline': {'id': 900, 'title': 'p', 'pipeline_status': 'active',
+                    'execution_mode': 'parallel'},
+        'epics': [_epic(90), _epic(91)],
+        'steps': [_step(9001, 90), _step(9101, 91)],
+        'step_requirements': [
+            {'step_fk': 9001, 'requirement_fk': 5010},
+            {'step_fk': 9101, 'requirement_fk': 5011},
+            {'step_fk': 9101, 'requirement_fk': 5012},
+        ],
+        'step_deps': [],
+        'requirements': [
+            _req(5010, status='met'), _req(5011, status='met'),
+            _req(5012, status='authoring'),
+        ],
+    }
+    counts = deriv.requirement_counts(model)
+    assert counts['overall'] == {'met': 2, 'total': 3}
+    by_epic = {b['epic_id']: b for b in counts['by_epic']}
+    assert by_epic[90] == {'epic_id': 90, 'met': 1, 'total': 1}
+    assert by_epic[91] == {'epic_id': 91, 'met': 1, 'total': 2}
+
+
+def test_requirement_counts_excludes_tracking_containers():
+    model = _basic_model()
+    model['requirements'].append(_req(5012, status='development', tracking=1))
+    model['step_requirements'].append({'step_fk': 9002, 'requirement_fk': 5012})
+    counts = deriv.requirement_counts(model)
+    assert counts['overall']['total'] == 2      # the container is not counted
+
+
+def test_requirement_with_no_step_link_counts_overall_not_by_epic():
+    model = _basic_model()
+    model['requirements'].append(_req(5099, status='authoring'))
+    counts = deriv.requirement_counts(model)
+    assert counts['overall']['total'] == 3
+    assert sum(b['total'] for b in counts['by_epic']) == 2
+
+
+def test_overall_population_follows_model_requirements_not_the_whole_plan():
+    """Documented residue (a code-review NOTE): on an EPIC-SCOPED `model`
+    (only that epic's own requirements present, matching what
+    `get_pipeline2_epic_composed` actually builds), `overall` is
+    indistinguishable from that epic's own `by_epic` entry — never the
+    plan's true total. A caller must label it as the epic's number, not the
+    plan's, on that resource."""
+    model = {
+        'pipeline': {'id': 900, 'title': 'p', 'pipeline_status': 'active',
+                    'execution_mode': 'parallel'},
+        'epics': [_epic(90)],                    # ONE epic, as an epic-scoped
+        'steps': [_step(9001, 90)],               # composed read narrows to
+        'step_requirements': [{'step_fk': 9001, 'requirement_fk': 5010}],
+        'step_deps': [],
+        'requirements': [_req(5010, status='met')],
+    }
+    counts = deriv.requirement_counts(model)
+    assert counts['overall'] == {'met': 1, 'total': 1}
+    assert counts['by_epic'] == [{'epic_id': 90, 'met': 1, 'total': 1}]
+    epic_entry = {k: v for k, v in counts['by_epic'][0].items() if k != 'epic_id'}
+    assert counts['overall'] == epic_entry
+
+
+# ---------------------------------------------------------------------------
+# Item 3 — no time-gate branch: step_deps rows are plain edges
+# ---------------------------------------------------------------------------
+
+# COVERS: DRV-004
+def test_step_deps_are_plain_edges_with_no_condition_kind():
+    model = _basic_model()
+    rows = {row['id']: row for row in deriv.build_plan_rows(model)}
+    assert set(rows[9003]['dep_ids']) == {9001, 9002}
+    assert 'time_deps' not in rows[9003]
+
+
+# ---------------------------------------------------------------------------
+# Item 4 — display order is a tree walk, epic-scoped state-banding
+# ---------------------------------------------------------------------------
+
+# COVERS: DRV-007
+def test_manual_sort_order_orders_the_epic_blocks():
+    """`epic_order` and the resulting row order both follow `sort_order` —
+    NOT a claim that epic blocks stay contiguous once a cross-epic edge
+    exists (they are not guaranteed to; see `test_cross_epic_dependency_
+    edge_is_legal_and_respected_topologically` below and the module
+    docstring's item 4)."""
+    model = {
+        'pipeline': {'id': 900, 'title': 'p', 'pipeline_status': 'active',
+                    'execution_mode': 'parallel'},
+        'epics': [_epic(90, sort_order=2), _epic(91, sort_order=1)],
+        'steps': [_step(9001, 90), _step(9101, 91)],
+        'step_requirements': [], 'step_deps': [], 'requirements': [],
+    }
+    rows = deriv.build_plan_rows(model)
+    ordered = deriv.display_order(rows, model['epics'])
+    assert ordered['epic_order'] == [91, 90]              # sort_order wins
+    assert [r['id'] for r in ordered['rows']] == [9101, 9001]
+
+
+def test_manual_sort_order_wins_over_derived_order():
+    model = {
+        'pipeline': {'id': 900, 'title': 'p', 'pipeline_status': 'active',
+                    'execution_mode': 'parallel'},
+        # epic 90 started (a done step) so would derive FIRST; epic 91 is
+        # unstarted and would derive LAST. A manual order on 91 overrides that.
+        'epics': [_epic(90), _epic(91, sort_order=1)],
+        'steps': [
+            _step(9001, 90, completed_at='2026-08-01 00:00:00'),
+            _step(9101, 91),
+        ],
+        'step_requirements': [], 'step_deps': [], 'requirements': [],
+    }
+    rows = deriv.build_plan_rows(model)
+    ordered = deriv.display_order(rows, model['epics'])
+    assert ordered['epic_order'] == [91, 90]
+
+
+def test_started_epics_order_by_earliest_activity_ahead_of_unstarted():
+    model = {
+        'pipeline': {'id': 900, 'title': 'p', 'pipeline_status': 'active',
+                    'execution_mode': 'parallel'},
+        'epics': [_epic(90), _epic(91), _epic(92)],
+        'steps': [
+            # epic 90: unstarted (all pending) -> creation order (id)
+            _step(9001, 90),
+            # epic 91: started later
+            _step(9101, 91, completed_at='2026-08-05 00:00:00',
+                 create_ts='2026-08-02 00:00:00'),
+            # epic 92: started earliest
+            _step(9201, 92, completed_at='2026-08-05 00:00:00',
+                 create_ts='2026-08-01 00:00:00'),
+        ],
+        'step_requirements': [], 'step_deps': [], 'requirements': [],
+    }
+    rows = deriv.build_plan_rows(model)
+    ordered = deriv.display_order(rows, model['epics'])
+    # started epics (92 earliest, then 91) precede the unstarted one (90).
+    assert ordered['epic_order'] == [92, 91, 90]
+
+
+# COVERS: DRV-020
+def test_three_step_single_epic_case_still_reports_amended_acceptance():
+    """The amended acceptance criterion, verbatim:
+    `1 pending, 2 pending, 3 done depending on 2` in ONE epic must still
+    report a state-banding violation
+    (memory/pipeline-2-visualizer-design.md § 5.3)."""
+    model = {
+        'pipeline': {'id': 900, 'title': 'p', 'pipeline_status': 'active',
+                    'execution_mode': 'parallel'},
+        'epics': [_epic(90)],
+        'steps': [
+            _step(1, 90),
+            _step(2, 90),
+            _step(3, 90, completed_at='2026-08-01 00:00:00'),
+        ],
+        'step_requirements': [], 'requirements': [],
+        'step_deps': [{'id': 1, 'step_fk': 3, 'dep_step_fk': 2}],
+    }
+    rows = deriv.build_plan_rows(model)
+    ordered = deriv.display_order(rows, model['epics'])
+    violations, _ = deriv.verify_order(ordered['rows'])
+    banding = [v for v in violations if v['invariant'] == 'state-banding']
+    assert banding, ('the amended acceptance criterion requires this case to '
+                     'still report — see visualizer-design.md § 5.3')
+    assert set(banding[0]['step_ids']) == {3, 1}
+
+
+# COVERS: DRV-020
+def test_epic_scoping_produces_zero_false_violations_across_epics():
+    """Measurement D (visualizer-design.md § 5.2): a finished epic's done
+    steps rendering above an unrelated epic's still-pending work must NOT be
+    reported — that is what containment asks for, and a global check would
+    wrongly flag it (measurement C, 15 false violations on the live plan)."""
+    model = {
+        'pipeline': {'id': 900, 'title': 'p', 'pipeline_status': 'active',
+                    'execution_mode': 'parallel'},
+        'epics': [_epic(90, sort_order=1), _epic(91, sort_order=2)],
+        'steps': [
+            # epic 90: fully done
+            _step(9001, 90, completed_at='2026-08-01 00:00:00'),
+            _step(9002, 90, completed_at='2026-08-01 00:00:00'),
+            # epic 91: still has pending work
+            _step(9101, 91),
+        ],
+        'step_requirements': [], 'step_deps': [], 'requirements': [],
+    }
+    rows = deriv.build_plan_rows(model)
+    ordered = deriv.display_order(rows, model['epics'])
+    violations, _ = deriv.verify_order(ordered['rows'])
+    assert [v for v in violations if v['invariant'] == 'state-banding'] == []
+
+
+# COVERS: DRV-012
+def test_cycle_within_one_epic_is_detected_and_falls_back_to_stored_order():
+    model = {
+        'pipeline': {'id': 900, 'title': 'p', 'pipeline_status': 'active',
+                    'execution_mode': 'parallel'},
+        'epics': [_epic(90)],
+        'steps': [_step(1, 90), _step(2, 90)],
+        'step_requirements': [], 'requirements': [],
+        'step_deps': [
+            {'id': 1, 'step_fk': 1, 'dep_step_fk': 2},
+            {'id': 2, 'step_fk': 2, 'dep_step_fk': 1},
+        ],
+    }
+    rows = deriv.build_plan_rows(model)
+    ordered = deriv.display_order(rows, model['epics'])
+    assert ordered['cycle_detected'] is True
+    assert set(ordered['cycle_step_ids']) == {1, 2}
+
+
+# COVERS: DRV-013
+def test_duplicate_step_id_is_reported():
+    model = _basic_model()
+    model['steps'].append(_step(9001, 90, title='duplicate'))
+    rows = deriv.build_plan_rows(model)
+    ordered = deriv.display_order(rows, model['epics'])
+    assert 9001 in ordered['duplicate_step_ids']
+
+
+# COVERS: DRV-014
+def test_dangling_dependency_is_detected_and_reported():
+    """A dep row pointing at a step id absent from the composed read's own
+    `steps` tier — a truncated read, or a stale FK — must be reported, not
+    silently swallowed."""
+    model = _basic_model()
+    model['step_deps'].append({'id': 3, 'step_fk': 9003, 'dep_step_fk': 424242})
+    rows = deriv.build_plan_rows(model)
+    ordered = deriv.display_order(rows, model['epics'])
+    violations, _ = deriv.verify_order(ordered['rows'])
+    dangling = [v for v in violations if v['invariant'] == 'dangling-dependency']
+    assert dangling and set(dangling[0]['step_ids']) == {9003, 424242}
+
+
+# COVERS: DRV-020
+def test_cross_epic_dependency_edge_is_legal_and_respected_topologically():
+    """Stage-2 gate delta (req #3336, 2026-08-08): cross-epic edges are
+    LEGAL, reversing the original body text. A step in epic 91 gated on a
+    still-pending step in epic 90 must never render before it, and the
+    epic-scoped banding check must not false-positive on the crossing."""
+    model = {
+        'pipeline': {'id': 900, 'title': 'p', 'pipeline_status': 'active',
+                    'execution_mode': 'parallel'},
+        'epics': [_epic(90, sort_order=1), _epic(91, sort_order=2)],
+        'steps': [
+            _step(9001, 90),                    # pending, gates 9101
+            _step(9101, 91),                     # pending, depends on 9001
+        ],
+        'step_requirements': [], 'requirements': [],
+        'step_deps': [{'id': 1, 'step_fk': 9101, 'dep_step_fk': 9001}],
+    }
+    rows = deriv.build_plan_rows(model)
+    ordered = deriv.display_order(rows, model['epics'])
+    positions = {row['id']: i for i, row in enumerate(ordered['rows'])}
+    assert positions[9001] < positions[9101], \
+        'a row must never render before a dependency, even across an epic'
+    violations, _ = deriv.verify_order(ordered['rows'])
+    assert [v for v in violations if v['invariant'] == 'topology'] == []
+    assert [v for v in violations if v['invariant'] == 'state-banding'] == []
+
+
+# ---------------------------------------------------------------------------
+# derive_step_state — unchanged rule, restated
+# ---------------------------------------------------------------------------
+
+# COVERS: DRV-009
+def test_derive_step_state_done_running_pending():
+    step = {'completed_at': None}
+    assert deriv.derive_step_state(step, [_req(1, status='development')]) == deriv.STEP_RUNNING
+    assert deriv.derive_step_state(step, [_req(1, status='met')]) == deriv.STEP_DONE
+    assert deriv.derive_step_state(step, [_req(1, status='authoring')]) == deriv.STEP_PENDING
+
+
+# COVERS: DRV-011
+def test_derive_step_state_with_no_gating_requirements_reads_completed_at():
+    assert deriv.derive_step_state({'completed_at': None}, []) == deriv.STEP_PENDING
+    assert deriv.derive_step_state({'completed_at': '2026-08-01'}, []) == deriv.STEP_DONE
+
+
+# COVERS: DRV-009
+def test_tracking_requirement_never_gates():
+    step = {'completed_at': None}
+    reqs = [_req(1, status='development', tracking=1)]
+    assert deriv.derive_step_state(step, reqs) == deriv.STEP_PENDING
+
+
+# COVERS: DRV-010
+def test_all_container_links_derive_from_completion_stamp_never_running():
+    """A step whose links are ALL tracking containers falls through to its
+    own `completed_at` stamp exactly as a link-less step does — Complete or
+    Scheduled, NEVER Running, even though a container sits in `development`."""
+    reqs = [_req(1, status='development', tracking=1)]
+    assert deriv.derive_step_state({'completed_at': None}, reqs) == deriv.STEP_PENDING
+    assert deriv.derive_step_state({'completed_at': '2026-08-01'}, reqs) == deriv.STEP_DONE
+
+
+# ---------------------------------------------------------------------------
+# Gate delta F9 — launch_req_ids / swarm_start_command / no_launch_reason
+# ---------------------------------------------------------------------------
+
+def test_launch_req_ids_only_swarm_ready_minus_containers():
+    model = _basic_model()
+    model['requirements'] = [
+        _req(5010, status='swarm_ready'),
+        _req(5011, status='met'),
+    ]
+    rows = {r['id']: r for r in deriv.build_plan_rows(model)}
+    assert rows[9001]['launch_req_ids'] == [5010]
+    assert rows[9001]['swarm_start_command'] == '/swarm-start 5010'
+    assert rows[9001]['no_launch_reason'] is None
+    assert rows[9002]['launch_req_ids'] == []
+    assert rows[9002]['swarm_start_command'] is None
+    assert '5011 met' in rows[9002]['launch_excluded']
+    assert rows[9002]['no_launch_reason'] is not None
+
+
+def test_no_launch_reason_distinguishes_no_links_from_containers():
+    model = _basic_model()
+    model['step_requirements'] = []
+    model['requirements'] = []
+    rows = {r['id']: r for r in deriv.build_plan_rows(model)}
+    assert rows[9001]['launch_block'] == deriv.BLOCK_NO_LINKS
+
+    model2 = _basic_model()
+    model2['requirements'] = [_req(5010, status='met', tracking=1),
+                              _req(5011, status='met')]
+    rows2 = {r['id']: r for r in deriv.build_plan_rows(model2)}
+    assert rows2[9001]['launch_block'] == deriv.BLOCK_CONTAINERS
+
+
+# ---------------------------------------------------------------------------
+# The whole derivation
+# ---------------------------------------------------------------------------
+
+def test_derive_plan2_shape_is_compact_ids_and_enums_only():
+    model = _basic_model()
+    plan = deriv.derive_plan2(model, now='2026-08-09T00:00:00Z')
+    assert set(plan) == {
+        'now', 'epic_order', 'display_order', 'rows', 'pause', 'serial',
+        'eligible_step_ids', 'violations', 'cycle_detected', 'cycle_step_ids',
+        'duplicate_step_ids', 'unresolved_req_ids', 'out_of_scope_dep_ids',
+        'requirement_counts'}
+    for row in plan['rows']:
+        assert set(row) == {
+            'id', 'state', 'run', 'eligible', 'epic_id', 'dep_ids',
+            'out_of_scope_dep_ids', 'req_ids',
+            'tracking_req_ids', 'unresolved_req_ids', 'launch_req_ids',
+            'launch_excluded', 'launch_block', 'swarm_start_command',
+            'no_launch_reason', 'launch_suppressed', 'suppressed_by'}
+
+
+# COVERS: DRV-006
+def test_derive_plan2_now_is_carried_for_a_later_eligibility_consumer():
+    model = _basic_model()
+    plan = deriv.derive_plan2(model, now='2026-08-09T00:00:00Z')
+    assert plan['now'] == '2026-08-09T00:00:00Z'
+
+
+# COVERS: DRV-015
+def test_derive_plan2_unresolved_requirement_is_reported_not_silently_dropped():
+    model = _basic_model()
+    model['step_requirements'].append({'step_fk': 9002, 'requirement_fk': 99999})
+    plan = deriv.derive_plan2(model, now='2026-08-09T00:00:00Z')
+    assert 99999 in plan['unresolved_req_ids']
+    row = next(r for r in plan['rows'] if r['id'] == 9002)
+    assert 99999 in row['unresolved_req_ids']
+
+
+# ---------------------------------------------------------------------------
+# Eligibility (DRV-005/006) — a plain per-step predicate, no batch term
+# ---------------------------------------------------------------------------
+
+def _pending_row(id, epic_id=90, dep_ids=None, not_before=None):
+    return {'id': id, 'state': deriv.STEP_PENDING, 'dep_ids': dep_ids or [],
+            'epic_id': epic_id, '_not_before': not_before}
+
+
+def _done_row(id, epic_id=90):
+    return {'id': id, 'state': deriv.STEP_DONE, 'dep_ids': [], 'epic_id': epic_id,
+            '_not_before': None}
+
+
+# COVERS: DRV-005
+def test_eligibility_requires_every_dependency_done():
+    dep = _pending_row(1)
+    row = _pending_row(2, dep_ids=[1])
+    by_id = {1: dep, 2: row}
+    assert deriv.eligibility(row, by_id, now='2026-08-09T00:00:00Z') is False
+    by_id[1] = _done_row(1)
+    assert deriv.eligibility(row, by_id, now='2026-08-09T00:00:00Z') is True
+
+
+# COVERS: DRV-005, DRV-006
+def test_eligibility_consults_not_before_against_the_payload_clock():
+    row = _pending_row(1, not_before='2026-08-10T00:00:00Z')
+    by_id = {1: row}
+    # the gate has not passed yet relative to this `now`
+    assert deriv.eligibility(row, by_id, now='2026-08-09T00:00:00Z') is False
+    # the gate has passed relative to a later `now`
+    assert deriv.eligibility(row, by_id, now='2026-08-11T00:00:00Z') is True
+    # no `now` at all while a gate exists means NOT eligible, never passed
+    assert deriv.eligibility(row, by_id, now=None) is False
+
+
+def test_eligibility_is_false_for_a_non_pending_row():
+    row = _done_row(1)
+    assert deriv.eligibility(row, {1: row}, now='2026-08-09T00:00:00Z') is False
+
+
+def test_derive_plan2_eligible_step_ids_reflects_the_dep_graph():
+    model = _basic_model()
+    model['requirements'] = [_req(5010, status='met'), _req(5011, status='met')]
+    plan = deriv.derive_plan2(model, now='2026-08-09T00:00:00Z')
+    # 9001/9002 are done (met requirements); 9003 gates on both -> eligible.
+    assert plan['eligible_step_ids'] == [9003]
+    row = next(r for r in plan['rows'] if r['id'] == 9003)
+    assert row['eligible'] is True
+
+
+# ---------------------------------------------------------------------------
+# Pause (DRV-016/017/018) — launch suppression, epic-scoped
+# ---------------------------------------------------------------------------
+
+def _paused_model(pipeline_status='active', epic_statuses=(None, None)):
+    return {
+        'pipeline': {'id': 900, 'title': 'p', 'pipeline_status': pipeline_status,
+                    'execution_mode': 'parallel'},
+        'epics': [
+            {**_epic(90), 'epic_status': epic_statuses[0] or 'active'},
+            {**_epic(91), 'epic_status': epic_statuses[1] or 'active'},
+        ],
+        'steps': [_step(9001, 90), _step(9101, 91)],
+        'step_requirements': [], 'step_deps': [], 'requirements': [],
+    }
+
+
+# COVERS: DRV-017
+def test_epic_pause_suppresses_only_that_epics_steps():
+    model = _paused_model(epic_statuses=('paused', 'active'))
+    rows = deriv.build_plan_rows(model)
+    ordered = deriv.display_order(rows, model['epics'])
+    pause = deriv.pause_state(model, ordered['rows'])
+    by_id = {r['id']: r for r in ordered['rows']}
+    assert by_id[9001]['launch_suppressed'] is True
+    assert by_id[9001]['suppressed_by'] == ['epic']
+    assert by_id[9101]['launch_suppressed'] is False
+    assert pause['paused_epic_ids'] == [90]
+    assert pause['suppressed_step_ids'] == [9001]
+
+
+# COVERS: DRV-016
+def test_launch_suppression_leaves_eligible_unchanged():
+    """`eligible` and `launch_suppressed` are independent — an
+    eligible-and-suppressed step must stay distinguishable from a
+    not-eligible one (DRV-016)."""
+    model = _paused_model(epic_statuses=('paused', 'active'))
+    plan = deriv.derive_plan2(model, now='2026-08-09T00:00:00Z')
+    row = next(r for r in plan['rows'] if r['id'] == 9001)
+    assert row['eligible'] is True                 # no deps, no time gate
+    assert row['launch_suppressed'] is True         # but its epic is paused
+    assert 9001 in plan['eligible_step_ids']         # eligibility is untouched
+
+
+# COVERS: DRV-018
+def test_whole_plan_pause_suppresses_every_epics_steps():
+    """A whole-plan pause binds a whole-plan orchestrator's every epic —
+    suppression is a property of the STEP regardless of which scope asks."""
+    model = _paused_model(pipeline_status='paused')
+    rows = deriv.build_plan_rows(model)
+    ordered = deriv.display_order(rows, model['epics'])
+    pause = deriv.pause_state(model, ordered['rows'])
+    assert pause['pipeline_paused'] is True
+    assert set(pause['suppressed_step_ids']) == {9001, 9101}
+    by_id = {r['id']: r for r in ordered['rows']}
+    assert by_id[9001]['suppressed_by'] == ['pipeline']
+    assert by_id[9101]['suppressed_by'] == ['pipeline']
+
+
+def test_suppressed_by_names_both_reasons_when_both_fire():
+    model = _paused_model(pipeline_status='paused', epic_statuses=('paused', 'active'))
+    rows = deriv.build_plan_rows(model)
+    ordered = deriv.display_order(rows, model['epics'])
+    pause = deriv.pause_state(model, ordered['rows'])
+    by_id = {r['id']: r for r in ordered['rows']}
+    assert by_id[9001]['suppressed_by'] == ['pipeline', 'epic']
+
+
+# ---------------------------------------------------------------------------
+# Epic-scoped reads and out-of-scope cross-epic dependencies
+#
+# Regression coverage for a code-review finding: `get_pipeline2_epic_composed`
+# narrows `steps` at the gateway but fetches `step_deps` by `step_fk`, so an
+# OUTGOING cross-epic edge names a `dep_step_fk` this payload never fetched.
+# `eligibility` correctly, permanently refuses to launch such a step (it
+# cannot know whether the dependency is done) — the defect was that
+# `verify_order` reported this as `dangling-dependency`, which reads as data
+# corruption rather than "read the whole-plan render for the true state".
+# ---------------------------------------------------------------------------
+
+def _epic_scoped_model_with_outgoing_edge():
+    return {
+        'pipeline': {'id': 900, 'title': 'p', 'pipeline_status': 'active',
+                    'execution_mode': 'parallel'},
+        'epics': [_epic(90)],                    # ONLY the requested epic
+        'steps': [_step(9001, 90)],               # ONLY that epic's own steps
+        'step_requirements': [], 'requirements': [],
+        # names a step in a DIFFERENT epic this payload never fetched
+        'step_deps': [{'id': 1, 'step_fk': 9001, 'dep_step_fk': 8888}],
+    }
+
+
+def test_epic_scoped_read_reports_out_of_scope_not_dangling():
+    model = _epic_scoped_model_with_outgoing_edge()
+    plan = deriv.derive_plan2(model, now='2026-08-09T00:00:00Z', epic_scoped=True)
+    assert plan['out_of_scope_dep_ids'] == [8888]
+    assert [v for v in plan['violations'] if v['invariant'] == 'dangling-dependency'] == []
+    # Still correctly NOT eligible — this payload cannot see whether 8888 is
+    # done, and the safe direction is not to guess.
+    row = next(r for r in plan['rows'] if r['id'] == 9001)
+    assert row['eligible'] is False
+    assert 9001 not in plan['eligible_step_ids']
+    # The reason is discoverable ON THE ROW, not just at plan level.
+    assert row['out_of_scope_dep_ids'] == [8888]
+
+
+def test_whole_plan_read_still_reports_a_genuinely_dangling_dependency():
+    """The SAME shape, read as a whole-plan payload (`epic_scoped=False`,
+    the default) — every epic is supposed to be present, so a missing dep
+    is a real defect (truncation or corruption) and must stay a loud
+    violation, unlike the epic-scoped case above."""
+    model = _epic_scoped_model_with_outgoing_edge()
+    plan = deriv.derive_plan2(model, now='2026-08-09T00:00:00Z')
+    assert plan['out_of_scope_dep_ids'] == []
+    dangling = [v for v in plan['violations'] if v['invariant'] == 'dangling-dependency']
+    assert dangling and set(dangling[0]['step_ids']) == {9001, 8888}
+
+
+# ---------------------------------------------------------------------------
+# The state-banding closure must be GLOBAL even though the comparison is
+# epic-scoped — regression coverage for a code-review finding: an earlier
+# version computed `depends_on` per epic, which cannot see a transitive
+# dependency path that leaves and re-enters an epic through another one.
+# ---------------------------------------------------------------------------
+
+def test_banding_closure_sees_a_transitive_path_through_another_epic():
+    """1 depends on 2 (epic 91), which depends on 3 (epic 90, same epic as
+    1). Topological order is [3, 2, 1]. Within epic 90's own two rows
+    ([3, 1] in that relative order), 1 (done) renders below 3 (pending) —
+    which LOOKS like an avoidable inversion unless the closure can see that
+    1 transitively depends on 3 through 2, which lives in epic 91."""
+    row1 = {'id': 1, 'state': deriv.STEP_DONE, 'epic_id': 90, 'dep_ids': [2]}
+    row2 = {'id': 2, 'state': deriv.STEP_PENDING, 'epic_id': 91, 'dep_ids': [3]}
+    row3 = {'id': 3, 'state': deriv.STEP_PENDING, 'epic_id': 90, 'dep_ids': []}
+    rows = [row3, row2, row1]                     # the topological order
+    violations, out_of_scope = deriv.verify_order(rows)
+    assert out_of_scope == []
+    assert [v for v in violations if v['invariant'] == 'state-banding'] == []
+
+
+# ---------------------------------------------------------------------------
+# Serial execution (gate delta, req #3388) — restated for 2.0
+#
+# The verification register has NO DRV-* entry for this at all (on any
+# requirement), which is a gap in the register, not evidence the work
+# belongs elsewhere — req #3349's own GATE DELTAS section names it
+# explicitly. See the module docstring's Scope section.
+# ---------------------------------------------------------------------------
+
+def _serial_model(execution_mode='serial'):
+    """Three epics in turn order 90 -> 91 -> 92. Epic 90 is fully done,
+    epic 91 has pending work (live), epic 92 is untouched (waiting)."""
+    return {
+        'pipeline': {'id': 900, 'title': 'p', 'pipeline_status': 'active',
+                    'execution_mode': execution_mode},
+        'epics': [_epic(90, sort_order=1), _epic(91, sort_order=2),
+                 _epic(92, sort_order=3)],
+        'steps': [
+            _step(9001, 90, completed_at='2026-08-01 00:00:00'),
+            _step(9101, 91),
+            _step(9201, 92),
+        ],
+        'step_requirements': [], 'step_deps': [], 'requirements': [],
+    }
+
+
+def test_serial_state_parallel_mode_holds_nothing():
+    model = _serial_model(execution_mode='parallel')
+    rows = deriv.build_plan_rows(model)
+    ordered = deriv.display_order(rows, model['epics'])
+    deriv.pause_state(model, ordered['rows'])
+    serial = deriv.serial_state(model, ordered['rows'], ordered['epic_order'])
+    assert serial == {
+        'execution_mode': 'parallel', 'serial': False,
+        'epic_order': [90, 91, 92], 'closed_epic_ids': [90],
+        'live_epic_id': 91, 'waiting_epic_ids': [92], 'held_step_ids': []}
+    by_id = {r['id']: r for r in ordered['rows']}
+    assert by_id[9201]['launch_suppressed'] is False
+
+
+def test_serial_state_serial_mode_holds_the_waiting_epic():
+    model = _serial_model(execution_mode='serial')
+    rows = deriv.build_plan_rows(model)
+    ordered = deriv.display_order(rows, model['epics'])
+    deriv.pause_state(model, ordered['rows'])
+    serial = deriv.serial_state(model, ordered['rows'], ordered['epic_order'])
+    assert serial['serial'] is True
+    assert serial['live_epic_id'] == 91
+    assert serial['waiting_epic_ids'] == [92]
+    assert serial['held_step_ids'] == [9201]
+    by_id = {r['id']: r for r in ordered['rows']}
+    assert by_id[9201]['launch_suppressed'] is True
+    assert by_id[9201]['suppressed_by'] == ['turn']
+    # The LIVE epic's own step is untouched.
+    assert by_id[9101]['launch_suppressed'] is False
+    # A closed epic's step is never held either (it is behind, not ahead).
+    assert by_id[9001]['launch_suppressed'] is False
+
+
+def test_serial_state_absent_execution_mode_reads_as_parallel():
+    model = _serial_model(execution_mode=None)
+    del model['pipeline']['execution_mode']
+    rows = deriv.build_plan_rows(model)
+    ordered = deriv.display_order(rows, model['epics'])
+    serial = deriv.serial_state(model, ordered['rows'], ordered['epic_order'])
+    assert serial['execution_mode'] == deriv.MODE_PARALLEL
+    assert serial['serial'] is False
+
+
+def test_turn_suppression_appends_to_pause_suppression():
+    """A step held by BOTH a pause and a turn names both reasons — pause
+    runs first and `serial_state` appends rather than replaces."""
+    model = _serial_model(execution_mode='serial')
+    model['epics'][2] = {**model['epics'][2], 'epic_status': 'paused'}   # epic 92
+    rows = deriv.build_plan_rows(model)
+    ordered = deriv.display_order(rows, model['epics'])
+    deriv.pause_state(model, ordered['rows'])
+    deriv.serial_state(model, ordered['rows'], ordered['epic_order'])
+    by_id = {r['id']: r for r in ordered['rows']}
+    assert by_id[9201]['suppressed_by'] == ['epic', 'turn']
+
+
+def test_derive_plan2_carries_the_serial_block():
+    model = _serial_model(execution_mode='serial')
+    plan = deriv.derive_plan2(model, now='2026-08-09T00:00:00Z')
+    assert plan['serial']['serial'] is True
+    assert plan['serial']['held_step_ids'] == [9201]
+    row = next(r for r in plan['rows'] if r['id'] == 9201)
+    assert row['launch_suppressed'] is True
+    assert row['suppressed_by'] == ['turn']
+
+
+def test_forward_cross_epic_edge_under_serial_is_not_a_deadlock():
+    """The ORDINARY case: a later epic's step depends on an earlier epic's
+    step. That is exactly how serial execution is meant to work and must
+    NOT be reported."""
+    model = _serial_model(execution_mode='serial')
+    model['step_deps'] = [{'id': 1, 'step_fk': 9101, 'dep_step_fk': 9001}]
+    plan = deriv.derive_plan2(model, now='2026-08-09T00:00:00Z')
+    assert [v for v in plan['violations'] if v['invariant'] == 'serial-deadlock'] == []
+
+
+def test_backward_cross_epic_edge_under_serial_is_a_loud_deadlock():
+    """The live epic's step depends on the WAITING epic's step — that
+    dependency can never be released (its epic never goes live while this
+    one, blocked on it, never closes). Must be a LOUD violation."""
+    model = _serial_model(execution_mode='serial')
+    # 9101 (epic 91, live) depends on 9201 (epic 92, waiting) — backward.
+    model['step_deps'] = [{'id': 1, 'step_fk': 9101, 'dep_step_fk': 9201}]
+    plan = deriv.derive_plan2(model, now='2026-08-09T00:00:00Z')
+    deadlocks = [v for v in plan['violations'] if v['invariant'] == 'serial-deadlock']
+    assert deadlocks and set(deadlocks[0]['step_ids']) == {9101, 9201}
+
+
+def test_backward_edge_under_parallel_mode_is_not_a_deadlock():
+    """The same backward edge under `parallel` execution is ordinary
+    topology (already checked elsewhere) — serial-deadlock only applies
+    when a turn order actually exists to violate."""
+    model = _serial_model(execution_mode='parallel')
+    model['step_deps'] = [{'id': 1, 'step_fk': 9101, 'dep_step_fk': 9201}]
+    plan = deriv.derive_plan2(model, now='2026-08-09T00:00:00Z')
+    assert [v for v in plan['violations'] if v['invariant'] == 'serial-deadlock'] == []
+
+
+# ---------------------------------------------------------------------------
+# Req #3367 deliverable 6 — three cases the corpus mapping below (module
+# docstring) found genuinely UNCOVERED once every translatable 1.0 case was
+# checked off against the tests above. Added here rather than left as a gap.
+# ---------------------------------------------------------------------------
+
+def test_empty_plan_derives_cleanly():
+    """`pipeline_conformance.json` case `empty-plan`, translated: the
+    degenerate input every loop here must survive. No epics, no steps — every
+    collection comes back empty and nothing raises."""
+    model = {'pipeline': {'id': 1, 'title': 'Empty', 'pipeline_status': 'draft'},
+            'epics': [], 'steps': [], 'step_requirements': [], 'step_deps': [],
+            'requirements': []}
+    plan = deriv.derive_plan2(model, now='2026-08-09T00:00:00Z')
+    assert plan['display_order'] == []
+    assert plan['rows'] == []
+    assert plan['violations'] == []
+    assert plan['cycle_detected'] is False
+    assert plan['requirement_counts']['overall'] == {'met': 0, 'total': 0}
+
+
+def test_tracking_flag_coercion_matrix():
+    """`pipeline_conformance.json` case `tracking-flag-coercion`, translated:
+    `is_tracking_requirement` reads MySQL's own TINYINT truthiness, not
+    Python's — a container link, once excluded from a step's GATING set, must
+    stay excluded across every spelling `tracking` might arrive in."""
+    truthy = (1, True, 2, '1', '2', -1)
+    falsy = (0, False, None, '', '0')
+    for value in truthy:
+        assert deriv.is_tracking_requirement({'tracking': value}) is True, value
+    for value in falsy:
+        assert deriv.is_tracking_requirement({'tracking': value}) is False, value
+
+
+def test_epic_sort_order_does_not_outrank_a_within_epic_state_band():
+    """`pipeline_conformance.json` case
+    `epic-sort-order-does-not-outrank-a-state-band`, translated: `sort_order`
+    is a CLUSTERING signal between epics (`display_order`'s epic_order), never
+    an override of the state-banding invariant WITHIN an epic. An epic given
+    `sort_order=1` (so it renders first) whose own steps still violate banding
+    must report that violation regardless of its position."""
+    model = {
+        'pipeline': {'id': 900, 'title': 'p', 'pipeline_status': 'active',
+                    'execution_mode': 'parallel'},
+        'epics': [_epic(90, sort_order=1), _epic(91, sort_order=2)],
+        'steps': [
+            _step(1, 90), _step(2, 90),
+            _step(3, 90, completed_at='2026-08-01 00:00:00'),
+            _step(9101, 91),
+        ],
+        'step_requirements': [], 'requirements': [],
+        'step_deps': [{'id': 1, 'step_fk': 3, 'dep_step_fk': 2}],
+    }
+    plan = deriv.derive_plan2(model, now='2026-08-09T00:00:00Z')
+    assert plan['epic_order'] == [90, 91], "sort_order still clusters the epics"
+    banding = [v for v in plan['violations'] if v['invariant'] == 'state-banding']
+    assert banding, ("sort_order must not suppress a genuine within-epic "
+                     "banding violation")
+    assert set(banding[0]['step_ids']) == {3, 1}


### PR DESCRIPTION
## Summary
- wip(Lambda-Rest): 2026-08-09T13:26:08Z
- chore: init swarm session feature/3367-pipeline-20-one-derivation-behind-a-1

## Files changed
```
 handler.py                             |   68 ++
 pipeline2_compose.py                   |  379 ++++++++++
 pipeline2_derive.py                    | 1200 ++++++++++++++++++++++++++++++++
 tests/test_pipeline2_compose.py        |  343 +++++++++
 tests/test_pipeline2_compose_budget.py |  142 ++++
 tests/test_pipeline2_derive.py         |  992 ++++++++++++++++++++++++++
 6 files changed, 3124 insertions(+)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Related PRs: BillWilliams79/DarwinAI-Config#923