### PR TITLE
Pipeline 2.0 - drop the Feature schema: the table, the junction, requirements.feature_fk, four registries and the IAM resource list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,15 +106,16 @@ empty.
 
 ## Outbound references — owning a row is not owning what it points at (req #3125)
 
-`CREATOR_TABLE_REFERENCES` is the fourth registry: **50 columns across 30
+`CREATOR_TABLE_REFERENCES` is the fourth registry: **47 columns across 29
 tables** — every `*_fk` on a `creator_fk`-bearing table whose target is also
 creator-scoped. (36 at req #3125; req #3186 added `swarm_sessions.pipeline_fk`
 and `.epic_fk`; req #3224 added `orchestration_claims.pipeline_fk`, `.epic_fk`
 and `.machine_fk`; req #3337 added four Pipeline 2.0 plan-layer columns;
 req #3369 added `orchestration_claims.pipeline2_fk` and `.epic2_fk`; req #3202
 added `swarm_completes.machine_fk`; req #3350 added `swarm_sessions.pipeline2_fk`
-and `.epic2_fk`. Every number is DERIVED — see the closing note of this
-section.)
+and `.epic2_fk`; req #3355 dropped the `features` entry (`category_fk`,
+`epic_fk`) and `requirements.feature_fk`, migration 20260811033413. Every
+number is DERIVED — see the closing note of this section.)
 
 **The attack does not defeat `creator_fk` scoping, it rides on it.** The attacker
 POSTs a row of their OWN, so the token-forced `creator_fk` is theirs and every
@@ -230,8 +231,9 @@ KEYS are SQL identifiers* rule, which had already defeated two other registries.
 
 **The candidates are DERIVED, the classification is written down.**
 `tests/test_unit_enum_blank.py` re-parses `schema.sql` for every NOT NULL column that is
-a real `ENUM(...)` or a CHAR/VARCHAR no wider than 32 — 46 columns today — and fails
-unless each is in `ENUM_COLUMNS` or `FREE_TEXT_NOT_NULL_COLUMNS` (41 + 5). A new enum
+a real `ENUM(...)` or a CHAR/VARCHAR no wider than 32 — 45 columns today (req #3355
+dropped `features.feature_status`) — and fails
+unless each is in `ENUM_COLUMNS` or `FREE_TEXT_NOT_NULL_COLUMNS` (40 + 5). A new enum
 column fails the build until registered.
 
 **That width rule is a FILTER, NOT A PROOF, and the difference is load-bearing.** It
@@ -239,7 +241,7 @@ sweeps the shapes an enum is usually written in; a bounded domain declared wider
 and simply will not be swept. Two are — `swarm_completes.skill_name` VARCHAR(64)
 (`VALID_COMPLETE_SKILL_NAMES`, two members) and `user_integrations.provider` VARCHAR(50)
 (`'strava'`) — both accepted `''` silently until they were **registered by hand**, which
-brings `ENUM_COLUMNS` to **43 columns across 28 tables**. The test asks a different
+brings `ENUM_COLUMNS` to **42 columns across 27 tables**. The test asks a different
 question of those: they are checked to EXIST in the DDL, not to have been swept. Raising
 the bound instead would drag in every VARCHAR(64) name and `creator_fk` itself, trading a
 reviewable exemption list for an unreviewable one. NOT NULL `TINYINT` flags are outside

--- a/auth_utils.py
+++ b/auth_utils.py
@@ -188,9 +188,11 @@ CREATOR_FK_TABLES = frozenset({
     'map_partners',
     'user_integrations',
     # Req #2380 — Swarm Features & Test Cases registry (migrations 042/043/044).
-    # Missing entries here are a silent security gap: unauthenticated writes
-    # to these tables would be accepted by the generic Lambda-Rest passthrough.
-    'features', 'test_cases', 'test_plans', 'test_runs', 'test_results',
+    # `features` left this set at req #3355 (Pipeline 2.0 Feature eradication,
+    # migration 20260811033413 — the table is dropped). Missing entries here
+    # are a silent security gap: unauthenticated writes to these tables would
+    # be accepted by the generic Lambda-Rest passthrough.
+    'test_cases', 'test_plans', 'test_runs', 'test_results',
     # Req #2422 — swarm_start log (migration 046). swarm_start_sessions is a
     # junction table with no creator_fk and stays out of this set.
     'swarm_starts',
@@ -353,14 +355,11 @@ JUNCTION_OWNERSHIP = {
         'verify': (('session_fk', 'swarm_sessions'),),
     },
 
-    # Features / test registry (req #2380, migrations 042-044).
-    'feature_test_cases': {
-        'scope': ('feature_fk', 'features'),
-        'verify': (('test_case_fk', 'test_cases'),),
-    },
     # Pipeline 2.0 Feature retirement — test cases re-home onto Requirement
-    # (req #3352, migration 20260809002149). Stands beside `feature_test_cases`
-    # above, not in its place, until req #3334's eradication sequencing.
+    # (req #3352, migration 20260809002149). `feature_test_cases` (req #2380,
+    # migrations 042-044), which this stood beside, was dropped at req #3355
+    # (migration 20260811033413) — the eradication sequencing this comment
+    # used to point at.
     'requirement_test_cases': {
         'scope': ('requirement_fk', 'requirements'),
         'verify': (('test_case_fk', 'test_cases'),),
@@ -534,10 +533,6 @@ CREATOR_TABLE_REFERENCES = {
     'epics': (
         ('category_fk', 'categories'),                       # RESTRICT
     ),
-    'features': (
-        ('category_fk', 'categories'),                       # RESTRICT
-        ('epic_fk', 'epics'),                                # SET NULL
-    ),
     'map_runs': (
         ('map_route_fk', 'map_routes'),                      # SET NULL
     ),
@@ -571,7 +566,8 @@ CREATOR_TABLE_REFERENCES = {
         ('project_fk', 'projects'),                          # SET NULL
         ('category_fk', 'categories'),                       # RESTRICT
         ('machine_fk', 'machines'),                          # RESTRICT
-        ('feature_fk', 'features'),                          # SET NULL
+        # ('feature_fk', 'features') dropped at req #3355 (migration
+        # 20260811033413) — the column no longer exists.
     ),
     'swarm_sessions': (
         ('machine_fk', 'machines'),                          # RESTRICT
@@ -690,7 +686,6 @@ ENUM_COLUMNS = {
     'build_projects': frozenset({'project_status'}),
     'categories': frozenset({'sort_mode'}),
     'epics': frozenset({'epic_status'}),
-    'features': frozenset({'feature_status'}),
     'machines': frozenset({'platform', 'arch'}),
     'map_runs': frozenset({'source'}),
     'pipeline2_epics': frozenset({'epic_status'}),

--- a/tests/test_creator_fk_references.py
+++ b/tests/test_creator_fk_references.py
@@ -79,7 +79,6 @@ def _purge(conn, creator):
                     "DELETE FROM test_plans WHERE creator_fk = %s",
                     "DELETE FROM test_cases WHERE creator_fk = %s",
                     "DELETE FROM requirements WHERE creator_fk = %s",
-                    "DELETE FROM features WHERE creator_fk = %s",
                     "DELETE FROM tasks WHERE creator_fk = %s",
                     "DELETE FROM recurring_tasks WHERE creator_fk = %s",
                     "DELETE FROM areas WHERE creator_fk = %s",
@@ -98,7 +97,7 @@ def _purge(conn, creator):
 # ---------------------------------------------------------------------------
 
 def _build_graph(post, label):
-    """project -> category -> {test_plan -> test_run, test_case, feature}, + domain -> area.
+    """project -> category -> {test_plan -> test_run, test_case}, + domain -> area.
 
     Built through the REST API rather than raw SQL on purpose: it is
     simultaneously the regression guard that an OWNER can still create every one
@@ -132,12 +131,6 @@ def _build_graph(post, label):
     assert resp['statusCode'] == 200, f'{label} test_case POST: {resp}'
     ids['test_case'] = extract_id(resp)
 
-    resp = post('/darwin_dev/features', {'title': f'{label} feature',
-                                         'description': f'{label} feature',
-                                         'category_fk': ids['category']})
-    assert resp['statusCode'] == 200, f'{label} feature POST: {resp}'
-    ids['feature'] = extract_id(resp)
-
     resp = post('/darwin_dev/domains', {'domain_name': f'{label[:12]} dom',
                                         'closed': '0'})
     assert resp['statusCode'] == 200, f'{label} domain POST: {resp}'
@@ -169,7 +162,6 @@ def _purge_owned(conn, creator):
                     "DELETE FROM test_plans WHERE creator_fk = %s",
                     "DELETE FROM test_cases WHERE creator_fk = %s",
                     "DELETE FROM requirements WHERE creator_fk = %s",
-                    "DELETE FROM features WHERE creator_fk = %s",
                     "DELETE FROM categories WHERE creator_fk = %s",
                     "DELETE FROM projects WHERE creator_fk = %s"):
                 cur.execute(statement, (creator,))
@@ -258,8 +250,6 @@ def test_the_victim_can_still_delete_their_own_plan_after_a_refused_attack(
     ('test_plans', 'category_fk', 'category', {'title': 'stolen category plan'}),
     ('test_cases', 'category_fk', 'category', {'title': 'stolen category case',
                                                'steps': 's', 'expected': 'e'}),
-    ('features', 'category_fk', 'category', {'title': 'stolen feature',
-                                             'description': 'd'}),
     ('categories', 'project_fk', 'project', {'category_name': 'stolen project cat'}),
     ('areas', 'domain_fk', 'domain', {'area_name': 'stolen domain area',
                                       'closed': '0'}),
@@ -289,7 +279,8 @@ def test_post_naming_any_victim_parent_is_refused(intruder, victim, attacker,
 
 def test_a_multi_parent_write_is_refused_on_any_one_foreign_parent(
         intruder, victim, attacker, db_connection):
-    """`requirements` names four parents. Owning three of them is not enough."""
+    """`requirements` names three parents (project_fk, category_fk, machine_fk —
+    feature_fk dropped at req #3355). Owning some of them is not enough."""
     before = _count(db_connection, 'requirements', 'category_fk', victim['category'])
 
     resp = intruder('POST', '/darwin_dev/requirements',

--- a/tests/test_creator_fk_references_exhaustive.py
+++ b/tests/test_creator_fk_references_exhaustive.py
@@ -3,8 +3,9 @@
 `test_creator_fk_references.py` covers the attack in depth on a handful of
 representative columns. This file covers it in BREADTH: the requirement asks for
 "cross-tenant test cases in the #3094/#3122 pattern **for every column, both
-verbs**", and that is 36 columns across 25 tables, so it is generated from the
-registry rather than hand-written 72 times.
+verbs**", and that is 47 columns across 29 tables (see
+`test_the_matrix_is_the_whole_registry` for the count's own history), so it is
+generated from the registry rather than hand-written 94 times.
 
 Generating from `CREATOR_TABLE_REFERENCES` is also the point. A hand-written list
 would drift from the registry exactly the way the registry would have drifted from
@@ -71,7 +72,6 @@ def _required_columns(table, seed):
         'dev_servers': {'port': 3000 + (seed_int(seed) % 8), 'pid': 999000,
                         'workspace_path': f'/tmp/{seed}'},
         'epics': {'title': f'{seed}-epic'},
-        'features': {'title': f'{seed}-feature', 'description': 'd'},
         'map_runs': {'run_id': seed_int(seed), 'activity_id': f'{seed}-act',
                      'activity_name': 'ride', 'start_time': '2026-07-27 00:00:00',
                      'run_time_sec': 1, 'distance_mi': 1},
@@ -131,9 +131,13 @@ def test_the_matrix_is_the_whole_registry():
     # (see `_required_columns`). #3350 fixes both gaps AND adds its own two
     # `swarm_sessions` 2.0 attribution siblings (pipeline2_fk/epic2_fk — no
     # new parent tables, both already built for #3337's own
-    # pipeline2_epics/pipeline2_steps entries), landing on 50.
-    assert len(TRIPLES) == 50, f'expected 50 registered columns, generated {len(TRIPLES)}'
-    assert len(PARENTS) == 24, PARENTS
+    # pipeline2_epics/pipeline2_steps entries), landing on 50. Req #3355 drops
+    # `features` — both its `requirements.feature_fk` column AND its own
+    # `('category_fk', 'categories')`/`('epic_fk', 'epics')` entry — taking
+    # TRIPLES to 47 and, since `features` was itself a PARENT of nothing else
+    # registered, PARENTS to 23.
+    assert len(TRIPLES) == 47, f'expected 47 registered columns, generated {len(TRIPLES)}'
+    assert len(PARENTS) == 23, PARENTS
     assert ('test_runs', 'test_plan_fk', 'test_plans') in TRIPLES
 
 
@@ -169,7 +173,7 @@ PURGE_ORDER = (
     'pipeline_steps', 'pipelines',
     'pipeline2_steps', 'pipeline2_epics', 'pipeline2_pipelines',
     'test_results', 'test_runs', 'test_plans', 'test_cases',
-    'requirements', 'features', 'epics',
+    'requirements', 'epics',
     'tasks', 'recurring_tasks', 'areas', 'domains',
     'builds', 'branches', 'build_projects', 'customers',
     'map_runs', 'map_routes',
@@ -207,7 +211,7 @@ def _make_invoke(sub):
 
 
 def _build_graph(invoke, seed):
-    """One owned row in each of the 24 parent tables, created THROUGH the gateway.
+    """One owned row in each of the 23 parent tables, created THROUGH the gateway.
 
     Doubling as the owner-side regression proof: every one of these POSTs now
     runs the ownership guard, so a rule that over-refuses fails here before any
@@ -257,7 +261,6 @@ def _build_graph(invoke, seed):
                                  category_fk=ids['categories']))
 
     # Three.
-    post('features', dict(req('features'), category_fk=ids['categories']))
     post('requirements', dict(req('requirements'), category_fk=ids['categories']))
     post('test_runs', dict(req('test_runs'), test_plan_fk=ids['test_plans']))
     post('pipeline2_steps', dict(req('pipeline2_steps'), epic_fk=ids['pipeline2_epics']))

--- a/tests/test_unit_creator_fk_references.py
+++ b/tests/test_unit_creator_fk_references.py
@@ -16,10 +16,11 @@ from the row pinning them: there is no self-service recovery at all.
 **The registry must be COMPLETE, and it is DERIVED here rather than reviewed.**
 That is the load-bearing test in this file. The audit that filed req #3125
 reported "test_runs.test_plan_fk and ten sibling columns"; re-deriving the same
-rule from `schema.sql` gives **41 columns across 26 tables** (36 when #3125
+rule from `schema.sql` gives **47 columns across 29 tables** (36 when #3125
 shipped; req #3186's two `swarm_sessions` attribution FKs and req #3224's three
 `orchestration_claims` ones are the proof the mechanism works — they failed this
-test until registered). A hand-counted
+test until registered; req #3355 dropped `features`, taking a column and a
+table back off the count). A hand-counted
 security boundary drifts silently — `test_every_cross_tenant_fk_column_is_registered`
 re-derives it on every run, so a new FK column fails the build instead.
 
@@ -398,8 +399,7 @@ ROWS = {'test_plans': {1: 'victim', 2: 'stranger'},
         'areas': {20: 'victim', 21: 'stranger'},
         'recurring_tasks': {30: 'victim'},
         'projects': {40: 'victim'},
-        'machines': {50: 'victim', 51: 'stranger'},
-        'features': {60: 'victim'}}
+        'machines': {50: 'victim', 51: 'stranger'}}
 
 
 def _check(table, bodies, user='victim', require_scope=True, rows=None):
@@ -513,11 +513,11 @@ def test_lookups_are_grouped_per_parent_table_not_per_row():
 
 
 def test_a_table_with_several_parents_asks_each_one_once():
-    """`requirements` names four different parent tables in one body."""
+    """`requirements` names three different parent tables in one body."""
     verdict, cursor = _check('requirements', [{'project_fk': 40, 'category_fk': 10,
-                                               'machine_fk': 50, 'feature_fk': 60}])
+                                               'machine_fk': 50}])
     assert verdict is None
-    assert len(cursor.queries) == 4
+    assert len(cursor.queries) == 3
 
 
 def test_a_foreign_parent_in_any_position_is_refused():


### PR DESCRIPTION
## Summary
- wip(Lambda-Rest): 2026-08-11T05:45:19Z
- chore: init swarm session feature/3355-pipeline-20-drop-the-feature-schema

## Files changed
```
 CLAUDE.md                                      | 14 +++++++------
 auth_utils.py                                  | 27 +++++++++++---------------
 tests/test_creator_fk_references.py            | 15 +++-----------
 tests/test_creator_fk_references_exhaustive.py | 21 +++++++++++---------
 tests/test_unit_creator_fk_references.py       | 14 ++++++-------
 5 files changed, 41 insertions(+), 50 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)