### PR TITLE
Pipeline 2.0 - eradicate the first-generation layer: its tables, commands, scripts, tests and document set

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,7 @@ empty.
 
 ## Outbound references — owning a row is not owning what it points at (req #3125)
 
-`CREATOR_TABLE_REFERENCES` is the fourth registry: **47 columns across 29
+`CREATOR_TABLE_REFERENCES` is the fourth registry: **40 columns across 26
 tables** — every `*_fk` on a `creator_fk`-bearing table whose target is also
 creator-scoped. (36 at req #3125; req #3186 added `swarm_sessions.pipeline_fk`
 and `.epic_fk`; req #3224 added `orchestration_claims.pipeline_fk`, `.epic_fk`
@@ -114,17 +114,20 @@ and `.machine_fk`; req #3337 added four Pipeline 2.0 plan-layer columns;
 req #3369 added `orchestration_claims.pipeline2_fk` and `.epic2_fk`; req #3202
 added `swarm_completes.machine_fk`; req #3350 added `swarm_sessions.pipeline2_fk`
 and `.epic2_fk`; req #3355 dropped the `features` entry (`category_fk`,
-`epic_fk`) and `requirements.feature_fk`, migration 20260811033413. Every
+`epic_fk`) and `requirements.feature_fk`, migration 20260811033413; req #3356
+dropped the whole 1.0 plan layer, migration 20260812175325 — the `epics`,
+`pipelines` and `pipeline_steps` entries with their tables, plus 1.0's two
+`swarm_sessions` and two `orchestration_claims` attribution columns. Every
 number is DERIVED — see the closing note of this section.)
 
 **The attack does not defeat `creator_fk` scoping, it rides on it.** The attacker
 POSTs a row of their OWN, so the token-forced `creator_fk` is theirs and every
 check above passes; the row merely names a **victim's** parent in a `*_fk`
-nobody was looking at. Where the FK is `ON DELETE RESTRICT` (14 of the 38) that
+nobody was looking at. Where the FK is `ON DELETE RESTRICT` (15 of the 40) that
 is a **grief-lock**: `DELETE /darwin/test_plans?id=<the victim's own>` answers 409
 naming `fk_test_runs_plan`, held by a `test_runs` row scoped to the attacker —
 invisible to the victim's GET, unaddressable by their PUT, untouchable by their
-DELETE. **No self-service recovery exists.** The other 24 (CASCADE / SET NULL) are
+DELETE. **No self-service recovery exists.** The other 25 (CASCADE / SET NULL) are
 cross-tenant attachment: the attacker's row living inside the victim's tree.
 
 Shape differs from `JUNCTION_OWNERSHIP` in two ways, both deliberate:
@@ -231,9 +234,10 @@ KEYS are SQL identifiers* rule, which had already defeated two other registries.
 
 **The candidates are DERIVED, the classification is written down.**
 `tests/test_unit_enum_blank.py` re-parses `schema.sql` for every NOT NULL column that is
-a real `ENUM(...)` or a CHAR/VARCHAR no wider than 32 — 45 columns today (req #3355
-dropped `features.feature_status`) — and fails
-unless each is in `ENUM_COLUMNS` or `FREE_TEXT_NOT_NULL_COLUMNS` (40 + 5). A new enum
+a real `ENUM(...)` or a CHAR/VARCHAR no wider than 32 — 41 columns today (req #3355
+dropped `features.feature_status`; req #3356 dropped `epics.epic_status`,
+`pipelines.pipeline_status`/`.execution_mode` and `pipeline_steps.run`) — and fails
+unless each is in `ENUM_COLUMNS` or `FREE_TEXT_NOT_NULL_COLUMNS` (36 + 5). A new enum
 column fails the build until registered.
 
 **That width rule is a FILTER, NOT A PROOF, and the difference is load-bearing.** It
@@ -241,7 +245,7 @@ sweeps the shapes an enum is usually written in; a bounded domain declared wider
 and simply will not be swept. Two are — `swarm_completes.skill_name` VARCHAR(64)
 (`VALID_COMPLETE_SKILL_NAMES`, two members) and `user_integrations.provider` VARCHAR(50)
 (`'strava'`) — both accepted `''` silently until they were **registered by hand**, which
-brings `ENUM_COLUMNS` to **42 columns across 27 tables**. The test asks a different
+brings `ENUM_COLUMNS` to **38 columns across 24 tables**. The test asks a different
 question of those: they are checked to EXIST in the DDL, not to have been swept. Raising
 the bound instead would drag in every VARCHAR(64) name and `creator_fk` itself, trading a
 reviewable exemption list for an unreviewable one. NOT NULL `TINYINT` flags are outside

--- a/auth_utils.py
+++ b/auth_utils.py
@@ -225,32 +225,25 @@ CREATOR_FK_TABLES = frozenset({
     # Req #3096 — per-document actual-token rows (migration 074). Carries
     # creator_fk like its parent row; scope generic passthrough the same way.
     'agent_telemetry_row_docs',
-    # Req #3111 — Swarm Orchestration foundation (migration 076). epics,
-    # pipelines and pipeline_steps each carry a NOT NULL creator_fk, so
-    # membership here is not optional hardening — it is what makes the generic
-    # passthrough work at all: rest_post injects creator_fk only for tables in
-    # this set, so an unregistered table's INSERT fails outright (the column has
-    # no default), and its GET would return every user's rows unscoped.
-    #
-    # pipeline_step_requirements and pipeline_step_deps stay OUT: neither has a
-    # creator_fk. They inherit ownership from their step, the same call made for
-    # every other junction (swarm_start_sessions, agent_documents, ...) — and
-    # since req #3122 that inheritance is ENFORCED, in JUNCTION_OWNERSHIP below,
-    # rather than merely asserted in a migration comment.
-    'epics', 'pipelines', 'pipeline_steps',
+    # Req #3111's `epics` / `pipelines` / `pipeline_steps` were registered here
+    # and were REMOVED at req #3356 (migration 20260812175325) along with the
+    # rest of the 1.0 plan layer. Their parallel-era successors are the three
+    # `pipeline2_*` tables below, registered on identical terms.
     # Req #3224 — the durable orchestration reservation (migration
     # 20260801150404). Carries a NOT NULL creator_fk, so membership here is what
-    # makes the generic passthrough work at all, exactly as for the #3111 three
-    # above. It is also the security-relevant half of a COORDINATION table: an
-    # unscoped LIST read would publish which machine and terminal every user is
-    # orchestrating from, and an unscoped DELETE would let anyone release
+    # makes the generic passthrough work at all: rest_post injects creator_fk
+    # only for tables in this set, so an unregistered table's INSERT fails
+    # outright (the column has no default), and its GET would return every user's
+    # rows unscoped. It is also the security-relevant half of a COORDINATION
+    # table: an unscoped LIST read publishes which machine and terminal every
+    # user is orchestrating from, and an unscoped DELETE would let anyone release
     # somebody else's live reservation — which is not a leak but a way to make
     # two orchestrators believe they both hold a scope.
     'orchestration_claims',
-    # Req #3337 — Pipeline 2.0 plan layer (migration 20260808115509). The
-    # parallel-era images of epics/pipelines/pipeline_steps: each carries a NOT
-    # NULL creator_fk, so membership here is what makes the generic passthrough
-    # work at all, exactly as for the #3111 three above.
+    # Req #3337 — Pipeline 2.0 plan layer (migration 20260808115509). The plan,
+    # its epics and its steps each carry a NOT NULL creator_fk, so membership
+    # here is what makes the generic passthrough work at all, exactly as for
+    # `orchestration_claims` above.
     #
     # pipeline2_step_requirements and pipeline2_step_deps stay OUT: neither has
     # a creator_fk. They inherit ownership from their step, in JUNCTION_OWNERSHIP
@@ -272,6 +265,8 @@ PROFILE_TABLE = 'profiles'
 # with another user's `id` fell into the unscoped `else` branch of rest_put /
 # rest_delete and rewrote or deleted that user's gate; `POST` with a foreign
 # `step_fk` injected a gate into their plan. Same shape on the other twelve.
+# (`pipeline_step_deps` and the rest of the 1.0 plan layer were dropped at
+# req #3356; the measurement is history and the rule it established is not.)
 #
 # NOT "the first junction with a surrogate id". Req #3111 flagged
 # `pipeline_step_deps` as the first junction whose rows are individually
@@ -296,7 +291,7 @@ PROFILE_TABLE = 'profiles'
 # BELONGS TO, not the one it points at. It becomes a predicate on every read,
 # update and delete:
 #
-#     step_fk IN (SELECT id FROM pipeline_steps WHERE creator_fk = %s)
+#     step_fk IN (SELECT id FROM pipeline2_steps WHERE creator_fk = %s)
 #
 # `verify` names the OTHER parent references, checked on INSERT only. A write is
 # refused when any of them names a row the caller does not own, which is what
@@ -310,25 +305,14 @@ PROFILE_TABLE = 'profiles'
 # for the one place that rule bites.
 
 JUNCTION_OWNERSHIP = {
-    # Swarm Orchestration (req #3111 migration 076; MCP surface req #3113).
-    # An edge and a requirement link both belong to their STEP.
-    'pipeline_step_deps': {
-        'scope': ('step_fk', 'pipeline_steps'),
-        # A cross-tenant edge is not just a leak: `dep_step_fk` is ON DELETE
-        # RESTRICT, so an edge pointing at somebody else's step would make THEIR
-        # step undeletable — a denial of service on another user's plan edit.
-        'verify': (('dep_step_fk', 'pipeline_steps'),),
-    },
-    'pipeline_step_requirements': {
-        'scope': ('step_fk', 'pipeline_steps'),
-        'verify': (('requirement_fk', 'requirements'),),
-    },
-
-    # Pipeline 2.0 plan layer (req #3337, migration 20260808115509). Identical
-    # shape to the 1.0 pair above and for identical reasons. `dep_step_fk` needs
-    # `verify` because it is ON DELETE RESTRICT: a cross-tenant edge would make
-    # somebody else's step undeletable, a denial of service rather than merely a
-    # leak.
+    # Pipeline 2.0 plan layer (req #3337, migration 20260808115509). An edge and
+    # a requirement link both belong to their STEP. `dep_step_fk` needs `verify`
+    # because it is ON DELETE RESTRICT: a cross-tenant edge would make somebody
+    # else's step undeletable, a denial of service rather than merely a leak.
+    #
+    # The 1.0 pair `pipeline_step_deps` / `pipeline_step_requirements` sat here
+    # on identical terms — they were req #3122's worked example — until
+    # req #3356 (migration 20260812175325) dropped the whole 1.0 plan layer.
     'pipeline2_step_deps': {
         'scope': ('step_fk', 'pipeline2_steps'),
         'verify': (('dep_step_fk', 'pipeline2_steps'),),
@@ -443,10 +427,10 @@ UNSCOPED_TABLES = frozenset()
 # target. Two consequences, and the second is the one that has no recovery:
 #
 #   * ATTACHMENT. The attacker's row is now a child of the victim's row. On the
-#     22 columns below that are CASCADE or SET NULL, that is the whole of it: a
+#     25 columns below that are CASCADE or SET NULL, that is the whole of it: a
 #     cross-tenant write, the same refusal req #3122 makes for junctions.
 #
-#   * GRIEF-LOCK. On the 14 columns that are ON DELETE RESTRICT, the victim can
+#   * GRIEF-LOCK. On the 15 columns that are ON DELETE RESTRICT, the victim can
 #     no longer delete their own parent. `DELETE /darwin/test_plans?id=<mine>`
 #     answers 409 naming `fk_test_runs_plan` — a constraint held by a `test_runs`
 #     row the victim cannot see (it is scoped to the attacker), cannot list, and
@@ -481,7 +465,7 @@ UNSCOPED_TABLES = frozenset()
 # COLUMNS DELIBERATELY NOT HERE. `creator_fk` itself (forced from the token, and
 # the only FK on these tables that targets `profiles`), and any FK whose target
 # is NOT creator-scoped — there is nobody to steal from. As of migration
-# 20260808115509 there are no such columns: all 45 non-`creator_fk` FKs on the 42
+# 20260812175325 there are no such columns: all 40 non-`creator_fk` FKs on the 38
 # creator-scoped tables target creator-scoped tables.
 #
 # ADDING A COLUMN. You do not — `test_every_cross_tenant_fk_column_is_registered`
@@ -530,21 +514,16 @@ CREATOR_TABLE_REFERENCES = {
         ('session_fk', 'swarm_sessions'),                    # SET NULL
         ('machine_fk', 'machines'),                          # RESTRICT
     ),
-    'epics': (
-        ('category_fk', 'categories'),                       # RESTRICT
-    ),
     'map_runs': (
         ('map_route_fk', 'map_routes'),                      # SET NULL
     ),
     'orchestration_claims': (                                # req #3224
-        ('pipeline_fk', 'pipelines'),                        # CASCADE
-        ('epic_fk', 'epics'),                                # CASCADE
+        # The 1.0 scope pair (`pipeline_fk` -> `pipelines`, `epic_fk` ->
+        # `epics`) was dropped with the rest of the 1.0 plan layer at req #3356
+        # (migration 20260812175325).
         ('machine_fk', 'machines'),                          # RESTRICT
         ('pipeline2_fk', 'pipeline2_pipelines'),             # CASCADE, req #3369
         ('epic2_fk', 'pipeline2_epics'),                     # CASCADE, req #3369
-    ),
-    'pipeline_steps': (
-        ('pipeline_fk', 'pipelines'),                        # CASCADE
     ),
     'pipeline2_epics': (                                     # req #3337
         ('pipeline_fk', 'pipeline2_pipelines'),              # CASCADE
@@ -555,9 +534,6 @@ CREATOR_TABLE_REFERENCES = {
     ),
     'pipeline2_steps': (                                     # req #3337
         ('epic_fk', 'pipeline2_epics'),                      # CASCADE
-    ),
-    'pipelines': (
-        ('machine_fk', 'machines'),                          # RESTRICT
     ),
     'recurring_tasks': (
         ('area_fk', 'areas'),                                # CASCADE
@@ -571,8 +547,9 @@ CREATOR_TABLE_REFERENCES = {
     ),
     'swarm_sessions': (
         ('machine_fk', 'machines'),                          # RESTRICT
-        ('pipeline_fk', 'pipelines'),                        # SET NULL  (req #3186)
-        ('epic_fk', 'epics'),                                # SET NULL  (req #3186)
+        # req #3186's 1.0 attribution pair (`pipeline_fk`, `epic_fk`) was
+        # dropped at req #3356 (migration 20260812175325); the 2.0 pair below
+        # is the surviving attribution.
         ('pipeline2_fk', 'pipeline2_pipelines'),             # SET NULL  (req #3350)
         ('epic2_fk', 'pipeline2_epics'),                     # SET NULL  (req #3350)
     ),
@@ -685,14 +662,11 @@ ENUM_COLUMNS = {
     'branches': frozenset({'branch_type'}),
     'build_projects': frozenset({'project_status'}),
     'categories': frozenset({'sort_mode'}),
-    'epics': frozenset({'epic_status'}),
     'machines': frozenset({'platform', 'arch'}),
     'map_runs': frozenset({'source'}),
     'pipeline2_epics': frozenset({'epic_status'}),
     'pipeline2_pipelines': frozenset({'pipeline_status', 'execution_mode'}),
     'pipeline2_steps': frozenset({'run'}),
-    'pipeline_steps': frozenset({'run'}),
-    'pipelines': frozenset({'pipeline_status', 'execution_mode'}),
     'profiles': frozenset({'theme_mode'}),
     'recurring_tasks': frozenset({'recurrence', 'insert_position'}),
     'requirements': frozenset({'requirement_status', 'coordination_type',
@@ -858,7 +832,7 @@ def junction_scope_clause(table):
     Returns a fragment carrying exactly ONE `%s` placeholder, which the caller
     binds to the authenticated user::
 
-        step_fk IN (SELECT id FROM pipeline_steps WHERE creator_fk = %s)
+        step_fk IN (SELECT id FROM pipeline2_steps WHERE creator_fk = %s)
 
     Table and column names come from the hard-coded registry above, never from a
     request, so the interpolation here introduces no injection surface. The

--- a/auth_utils.py
+++ b/auth_utils.py
@@ -245,10 +245,10 @@ CREATOR_FK_TABLES = frozenset({
     # here is what makes the generic passthrough work at all, exactly as for
     # `orchestration_claims` above.
     #
-    # pipeline2_step_requirements and pipeline2_step_deps stay OUT: neither has
+    # pipeline_step_requirements and pipeline_step_deps stay OUT: neither has
     # a creator_fk. They inherit ownership from their step, in JUNCTION_OWNERSHIP
     # below.
-    'pipeline2_pipelines', 'pipeline2_epics', 'pipeline2_steps',
+    'pipelines', 'epics', 'pipeline_steps',
 })
 
 PROFILE_TABLE = 'profiles'
@@ -291,7 +291,7 @@ PROFILE_TABLE = 'profiles'
 # BELONGS TO, not the one it points at. It becomes a predicate on every read,
 # update and delete:
 #
-#     step_fk IN (SELECT id FROM pipeline2_steps WHERE creator_fk = %s)
+#     step_fk IN (SELECT id FROM pipeline_steps WHERE creator_fk = %s)
 #
 # `verify` names the OTHER parent references, checked on INSERT only. A write is
 # refused when any of them names a row the caller does not own, which is what
@@ -313,12 +313,12 @@ JUNCTION_OWNERSHIP = {
     # The 1.0 pair `pipeline_step_deps` / `pipeline_step_requirements` sat here
     # on identical terms — they were req #3122's worked example — until
     # req #3356 (migration 20260812175325) dropped the whole 1.0 plan layer.
-    'pipeline2_step_deps': {
-        'scope': ('step_fk', 'pipeline2_steps'),
-        'verify': (('dep_step_fk', 'pipeline2_steps'),),
+    'pipeline_step_deps': {
+        'scope': ('step_fk', 'pipeline_steps'),
+        'verify': (('dep_step_fk', 'pipeline_steps'),),
     },
-    'pipeline2_step_requirements': {
-        'scope': ('step_fk', 'pipeline2_steps'),
+    'pipeline_step_requirements': {
+        'scope': ('step_fk', 'pipeline_steps'),
         'verify': (('requirement_fk', 'requirements'),),
     },
 
@@ -522,18 +522,18 @@ CREATOR_TABLE_REFERENCES = {
         # `epics`) was dropped with the rest of the 1.0 plan layer at req #3356
         # (migration 20260812175325).
         ('machine_fk', 'machines'),                          # RESTRICT
-        ('pipeline2_fk', 'pipeline2_pipelines'),             # CASCADE, req #3369
-        ('epic2_fk', 'pipeline2_epics'),                     # CASCADE, req #3369
+        ('pipeline_fk', 'pipelines'),             # CASCADE, req #3369
+        ('epic_fk', 'epics'),                     # CASCADE, req #3369
     ),
-    'pipeline2_epics': (                                     # req #3337
-        ('pipeline_fk', 'pipeline2_pipelines'),              # CASCADE
+    'epics': (                                     # req #3337
+        ('pipeline_fk', 'pipelines'),              # CASCADE
         ('category_fk', 'categories'),                       # RESTRICT
     ),
-    'pipeline2_pipelines': (                                 # req #3337
+    'pipelines': (                                 # req #3337
         ('machine_fk', 'machines'),                          # RESTRICT
     ),
-    'pipeline2_steps': (                                     # req #3337
-        ('epic_fk', 'pipeline2_epics'),                      # CASCADE
+    'pipeline_steps': (                                     # req #3337
+        ('epic_fk', 'epics'),                      # CASCADE
     ),
     'recurring_tasks': (
         ('area_fk', 'areas'),                                # CASCADE
@@ -550,8 +550,8 @@ CREATOR_TABLE_REFERENCES = {
         # req #3186's 1.0 attribution pair (`pipeline_fk`, `epic_fk`) was
         # dropped at req #3356 (migration 20260812175325); the 2.0 pair below
         # is the surviving attribution.
-        ('pipeline2_fk', 'pipeline2_pipelines'),             # SET NULL  (req #3350)
-        ('epic2_fk', 'pipeline2_epics'),                     # SET NULL  (req #3350)
+        ('pipeline_fk', 'pipelines'),             # SET NULL  (req #3350)
+        ('epic_fk', 'epics'),                     # SET NULL  (req #3350)
     ),
     'swarm_completes': (
         # req #3202, migration 20260809002208. The one envelope context column
@@ -664,9 +664,9 @@ ENUM_COLUMNS = {
     'categories': frozenset({'sort_mode'}),
     'machines': frozenset({'platform', 'arch'}),
     'map_runs': frozenset({'source'}),
-    'pipeline2_epics': frozenset({'epic_status'}),
-    'pipeline2_pipelines': frozenset({'pipeline_status', 'execution_mode'}),
-    'pipeline2_steps': frozenset({'run'}),
+    'epics': frozenset({'epic_status'}),
+    'pipelines': frozenset({'pipeline_status', 'execution_mode'}),
+    'pipeline_steps': frozenset({'run'}),
     'profiles': frozenset({'theme_mode'}),
     'recurring_tasks': frozenset({'recurrence', 'insert_position'}),
     'requirements': frozenset({'requirement_status', 'coordination_type',
@@ -832,7 +832,7 @@ def junction_scope_clause(table):
     Returns a fragment carrying exactly ONE `%s` placeholder, which the caller
     binds to the authenticated user::
 
-        step_fk IN (SELECT id FROM pipeline2_steps WHERE creator_fk = %s)
+        step_fk IN (SELECT id FROM pipeline_steps WHERE creator_fk = %s)
 
     Table and column names come from the hard-coded registry above, never from a
     request, so the interpolation here introduces no injection surface. The

--- a/handler.py
+++ b/handler.py
@@ -16,15 +16,15 @@ from auth_utils import (get_authenticated_user, CREATOR_FK_TABLES,
 import pipeline2_compose
 
 # req #3367 — the ONE non-generic route (remediation B, composing form).
-# `pipeline2_compose` / `pipeline2_compose_epic` are not real tables; they are
+# `pipeline_compose` / `pipeline_compose_epic` are not real tables; they are
 # reserved route names dispatched to `pipeline2_compose.py` BEFORE the generic
 # `{database}/{table}` gateway ever sees them. GET only, `id` as a query
 # string parameter — same grammar as every other single-row lookup
-# (`GET /darwin/pipeline2_compose?id=5`), so the existing darwin-mcp REST
+# (`GET /darwin/pipeline_compose?id=5`), so the existing darwin-mcp REST
 # client needs no new URL-building code, only a new response-shape method.
-PIPELINE2_COMPOSE_ROUTES = {
-    'pipeline2_compose': pipeline2_compose.compose_pipeline2,
-    'pipeline2_compose_epic': pipeline2_compose.compose_pipeline2_epic,
+PIPELINE_COMPOSE_ROUTES = {
+    'pipeline_compose': pipeline2_compose.compose_pipeline2,
+    'pipeline_compose_epic': pipeline2_compose.compose_pipeline2_epic,
 }
 
 
@@ -147,8 +147,8 @@ def rest_api_from_table(event, db_info):
 
     # req #3367 — the composing route, dispatched BEFORE the generic gateway
     # (these are not real tables, so DESC/CRUD below would only ever fail).
-    if table in PIPELINE2_COMPOSE_ROUTES:
-        return _rest_pipeline2_compose(table, conn, event, http_method,
+    if table in PIPELINE_COMPOSE_ROUTES:
+        return _rest_pipeline_compose(table, conn, event, http_method,
                                        authenticated_user)
 
     # Block unauthenticated access to user-scoped tables.
@@ -196,7 +196,7 @@ def rest_api_from_table(event, db_info):
         return rest_delete(delete_method, conn, database, table, body, authenticated_user)
 
 
-def _rest_pipeline2_compose(table, conn, event, http_method, authenticated_user):
+def _rest_pipeline_compose(table, conn, event, http_method, authenticated_user):
     """req #3367 — GET-only, `id` as a query-string parameter, same shape as
     every other single-row lookup. Not a real table, so PUT/POST/DELETE and a
     missing/malformed `id` are refused here rather than reaching pymysql."""
@@ -217,7 +217,7 @@ def _rest_pipeline2_compose(table, conn, event, http_method, authenticated_user)
                                      "parameter is required")
 
     try:
-        composed = PIPELINE2_COMPOSE_ROUTES[table](conn, row_id, authenticated_user)
+        composed = PIPELINE_COMPOSE_ROUTES[table](conn, row_id, authenticated_user)
     except ValueError as e:
         # A data-integrity issue (epic names a pipeline_fk that does not
         # resolve for this creator) — real but not the caller's fault to fix

--- a/pipeline2_compose.py
+++ b/pipeline2_compose.py
@@ -23,12 +23,12 @@ exception must never take the real rows down with it, so it degrades to a
 WITHHELD stub exactly as darwin-mcp's `_derive` guard did.
 
 Scoping mirrors what the generic gateway already does for every read of a
-`CREATOR_FK_TABLES` table (`rest_get_table.py`): every `pipeline2_pipelines` /
-`pipeline2_epics` / `pipeline2_steps` / `requirements` SELECT carries
+`CREATOR_FK_TABLES` table (`rest_get_table.py`): every `pipelines` /
+`epics` / `pipeline_steps` / `requirements` SELECT carries
 `creator_fk = %s` explicitly, not merely inherited through containment — the
 same defense-in-depth the generic gateway gave for free, replicated by hand
-because this route bypasses it. `pipeline2_step_requirements` and
-`pipeline2_step_deps` carry no `creator_fk` (JUNCTION_OWNERSHIP, req #3122) —
+because this route bypasses it. `pipeline_step_requirements` and
+`pipeline_step_deps` carry no `creator_fk` (JUNCTION_OWNERSHIP, req #3122) —
 scoped by narrowing to the already-scoped `step_fk` ids fetched above them,
 exactly as the daemon's own composed read did.
 """
@@ -283,14 +283,14 @@ def compose_pipeline2(conn, pipeline_id, authenticated_user):
     """THE whole-plan composed render. Returns None when not found (or not
     owned by `authenticated_user`) — the caller answers 404."""
     with conn.cursor(pymysql.cursors.DictCursor) as cursor:
-        pipelines = _select(cursor, _PIPELINE_COLUMNS, 'pipeline2_pipelines',
+        pipelines = _select(cursor, _PIPELINE_COLUMNS, 'pipelines',
                             'id = %s AND creator_fk = %s',
                             (pipeline_id, authenticated_user))               # read 1
         if not pipelines:
             return None
         pipeline = pipelines[0]
 
-        epics = _select(cursor, _EPIC_COLUMNS, 'pipeline2_epics',
+        epics = _select(cursor, _EPIC_COLUMNS, 'epics',
                         'pipeline_fk = %s AND creator_fk = %s',
                         (pipeline_id, authenticated_user), order_by='id ASC')  # read 2
 
@@ -298,7 +298,7 @@ def compose_pipeline2(conn, pipeline_id, authenticated_user):
         if epics:
             epic_ids = sorted(e['id'] for e in epics)
             steps = _select(
-                cursor, _STEP_COLUMNS, 'pipeline2_steps',
+                cursor, _STEP_COLUMNS, 'pipeline_steps',
                 f'epic_fk IN {_in_clause(len(epic_ids))} AND creator_fk = %s',
                 tuple(epic_ids) + (authenticated_user,), order_by='id ASC')    # read 3
         pipeline['step_count'] = len(steps)
@@ -307,10 +307,10 @@ def compose_pipeline2(conn, pipeline_id, authenticated_user):
         if steps:
             step_ids = sorted(s['id'] for s in steps)
             in_clause = _in_clause(len(step_ids))
-            links = _select(cursor, _LINK_COLUMNS, 'pipeline2_step_requirements',
+            links = _select(cursor, _LINK_COLUMNS, 'pipeline_step_requirements',
                             f'step_fk IN {in_clause}', tuple(step_ids),
                             order_by='step_fk ASC, requirement_fk ASC')       # read 4
-            deps = _select(cursor, _DEP_COLUMNS, 'pipeline2_step_deps',
+            deps = _select(cursor, _DEP_COLUMNS, 'pipeline_step_deps',
                            f'step_fk IN {in_clause}', tuple(step_ids),
                            order_by='step_fk ASC, id ASC')                    # read 5
 
@@ -343,14 +343,14 @@ def compose_pipeline2_epic(conn, epic_id, authenticated_user):
     row are both required (two independent pause scopes). Returns None when
     not found / not owned."""
     with conn.cursor(pymysql.cursors.DictCursor) as cursor:
-        epics = _select(cursor, _EPIC_COLUMNS, 'pipeline2_epics',
+        epics = _select(cursor, _EPIC_COLUMNS, 'epics',
                         'id = %s AND creator_fk = %s',
                         (epic_id, authenticated_user))                        # read 1
         if not epics:
             return None
         epic = epics[0]
 
-        pipelines = _select(cursor, _PIPELINE_COLUMNS, 'pipeline2_pipelines',
+        pipelines = _select(cursor, _PIPELINE_COLUMNS, 'pipelines',
                             'id = %s AND creator_fk = %s',
                             (epic['pipeline_fk'], authenticated_user))        # read 2
         if not pipelines:
@@ -360,7 +360,7 @@ def compose_pipeline2_epic(conn, epic_id, authenticated_user):
                 "creator. Data integrity issue — report it.")
         pipeline = pipelines[0]
 
-        steps = _select(cursor, _STEP_COLUMNS, 'pipeline2_steps',
+        steps = _select(cursor, _STEP_COLUMNS, 'pipeline_steps',
                         'epic_fk = %s AND creator_fk = %s',
                         (epic_id, authenticated_user), order_by='id ASC')     # read 3
         epic['step_count'] = len(steps)
@@ -369,10 +369,10 @@ def compose_pipeline2_epic(conn, epic_id, authenticated_user):
         if steps:
             step_ids = sorted(s['id'] for s in steps)
             in_clause = _in_clause(len(step_ids))
-            links = _select(cursor, _LINK_COLUMNS, 'pipeline2_step_requirements',
+            links = _select(cursor, _LINK_COLUMNS, 'pipeline_step_requirements',
                             f'step_fk IN {in_clause}', tuple(step_ids),
                             order_by='step_fk ASC, requirement_fk ASC')       # read 4
-            deps = _select(cursor, _DEP_COLUMNS, 'pipeline2_step_deps',
+            deps = _select(cursor, _DEP_COLUMNS, 'pipeline_step_deps',
                            f'step_fk IN {in_clause}', tuple(step_ids),
                            order_by='step_fk ASC, id ASC')                    # read 5
 

--- a/tests/test_creator_fk_references_exhaustive.py
+++ b/tests/test_creator_fk_references_exhaustive.py
@@ -82,9 +82,9 @@ def _required_columns(table, seed):
         'orchestration_claims': {},
         # Req #3337. The only NOT NULL, no-default, non-reference column each of
         # the three carries is `title`.
-        'pipeline2_pipelines': {'title': f'{seed}-p2pipeline'},
-        'pipeline2_epics': {'title': f'{seed}-p2epic'},
-        'pipeline2_steps': {'title': f'{seed}-p2step'},
+        'pipelines': {'title': f'{seed}-p2pipeline'},
+        'epics': {'title': f'{seed}-p2epic'},
+        'pipeline_steps': {'title': f'{seed}-p2step'},
         'recurring_tasks': {'description': f'{seed}-rt', 'recurrence': 'daily',
                             'anchor_date': '2026-07-27'},
         'requirements': {'title': f'{seed}-req', 'ai_model': 'opus',
@@ -174,7 +174,7 @@ PURGE_ORDER = (
     # only this safety-net sweep for rows a test case creates and does not
     # itself `_drop`.
     'orchestration_claims',
-    'pipeline2_steps', 'pipeline2_epics', 'pipeline2_pipelines',
+    'pipeline_steps', 'epics', 'pipelines',
     'test_results', 'test_runs', 'test_plans', 'test_cases',
     'requirements',
     'tasks', 'recurring_tasks', 'areas', 'domains',
@@ -243,7 +243,7 @@ def _build_graph(invoke, seed):
     post('swarm_sessions', req('swarm_sessions'))
     post('swarm_starts', req('swarm_starts'))
     post('agent_telemetry_runs', req('agent_telemetry_runs'))
-    post('pipeline2_pipelines', req('pipeline2_pipelines'))
+    post('pipelines', req('pipelines'))
 
     # One level down.
     post('categories', dict(req('categories'), project_fk=ids['projects']))
@@ -257,14 +257,14 @@ def _build_graph(invoke, seed):
     post('test_cases', dict(req('test_cases'), category_fk=ids['categories']))
     post('recurring_tasks', dict(req('recurring_tasks'), area_fk=ids['areas']))
     post('builds', dict(req('builds'), branch_fk=ids['branches']))
-    post('pipeline2_epics', dict(req('pipeline2_epics'),
-                                 pipeline_fk=ids['pipeline2_pipelines'],
+    post('epics', dict(req('epics'),
+                                 pipeline_fk=ids['pipelines'],
                                  category_fk=ids['categories']))
 
     # Three.
     post('requirements', dict(req('requirements'), category_fk=ids['categories']))
     post('test_runs', dict(req('test_runs'), test_plan_fk=ids['test_plans']))
-    post('pipeline2_steps', dict(req('pipeline2_steps'), epic_fk=ids['pipeline2_epics']))
+    post('pipeline_steps', dict(req('pipeline_steps'), epic_fk=ids['epics']))
 
     missing = [p for p in PARENTS if p not in ids]
     assert not missing, f'{seed} graph is missing parent rows for {missing}'

--- a/tests/test_creator_fk_references_exhaustive.py
+++ b/tests/test_creator_fk_references_exhaustive.py
@@ -3,9 +3,9 @@
 `test_creator_fk_references.py` covers the attack in depth on a handful of
 representative columns. This file covers it in BREADTH: the requirement asks for
 "cross-tenant test cases in the #3094/#3122 pattern **for every column, both
-verbs**", and that is 47 columns across 29 tables (see
+verbs**", and that is 40 columns across 26 tables (see
 `test_the_matrix_is_the_whole_registry` for the count's own history), so it is
-generated from the registry rather than hand-written 94 times.
+generated from the registry rather than hand-written 80 times.
 
 Generating from `CREATOR_TABLE_REFERENCES` is also the point. A hand-written list
 would drift from the registry exactly the way the registry would have drifted from
@@ -71,20 +71,17 @@ def _required_columns(table, seed):
         'customer_releases': {},
         'dev_servers': {'port': 3000 + (seed_int(seed) % 8), 'pid': 999000,
                         'workspace_path': f'/tmp/{seed}'},
-        'epics': {'title': f'{seed}-epic'},
         'map_runs': {'run_id': seed_int(seed), 'activity_id': f'{seed}-act',
                      'activity_name': 'ride', 'start_time': '2026-07-27 00:00:00',
                      'run_time_sec': 1, 'distance_mi': 1},
         # Req #3224. NO required non-reference columns: `polls` and `claimed_at`
-        # carry DEFAULTs, `epic_key` is GENERATED, and `creator_fk` is forced
+        # carry DEFAULTs, `epic2_key` is GENERATED, and `creator_fk` is forced
         # from the token — so the body is exactly the three references the test
-        # adds. Its UNIQUE (pipeline_fk, epic_key) is why `_drop` matters here,
+        # adds. Its UNIQUE (pipeline2_fk, epic2_key) is why `_drop` matters here,
         # like the three tables named in that function.
         'orchestration_claims': {},
-        'pipeline_steps': {'title': f'{seed}-step'},
-        'pipelines': {'title': f'{seed}-pipeline'},
-        # Req #3337. Like `epics`/`pipelines` above, the only NOT NULL,
-        # no-default, non-reference column each carries is `title`.
+        # Req #3337. The only NOT NULL, no-default, non-reference column each of
+        # the three carries is `title`.
         'pipeline2_pipelines': {'title': f'{seed}-p2pipeline'},
         'pipeline2_epics': {'title': f'{seed}-p2epic'},
         'pipeline2_steps': {'title': f'{seed}-p2step'},
@@ -136,8 +133,15 @@ def test_the_matrix_is_the_whole_registry():
     # `('category_fk', 'categories')`/`('epic_fk', 'epics')` entry — taking
     # TRIPLES to 47 and, since `features` was itself a PARENT of nothing else
     # registered, PARENTS to 23.
-    assert len(TRIPLES) == 47, f'expected 47 registered columns, generated {len(TRIPLES)}'
-    assert len(PARENTS) == 23, PARENTS
+    #
+    # Req #3356 drops the whole 1.0 plan layer (migration 20260812175325): the
+    # `epics`, `pipelines` and `pipeline_steps` registry entries go with their
+    # tables (-3 columns), and so do 1.0's two `swarm_sessions` and two
+    # `orchestration_claims` attribution columns (-4) — TRIPLES 47 -> 40.
+    # `epics` and `pipelines` were PARENTS of nothing but each other and those
+    # attribution columns, so PARENTS 23 -> 21.
+    assert len(TRIPLES) == 40, f'expected 40 registered columns, generated {len(TRIPLES)}'
+    assert len(PARENTS) == 21, PARENTS
     assert ('test_runs', 'test_plan_fk', 'test_plans') in TRIPLES
 
 
@@ -170,10 +174,9 @@ PURGE_ORDER = (
     # only this safety-net sweep for rows a test case creates and does not
     # itself `_drop`.
     'orchestration_claims',
-    'pipeline_steps', 'pipelines',
     'pipeline2_steps', 'pipeline2_epics', 'pipeline2_pipelines',
     'test_results', 'test_runs', 'test_plans', 'test_cases',
-    'requirements', 'epics',
+    'requirements',
     'tasks', 'recurring_tasks', 'areas', 'domains',
     'builds', 'branches', 'build_projects', 'customers',
     'map_runs', 'map_routes',
@@ -211,7 +214,7 @@ def _make_invoke(sub):
 
 
 def _build_graph(invoke, seed):
-    """One owned row in each of the 23 parent tables, created THROUGH the gateway.
+    """One owned row in each of the 21 parent tables, created THROUGH the gateway.
 
     Doubling as the owner-side regression proof: every one of these POSTs now
     runs the ownership guard, so a rule that over-refuses fails here before any
@@ -239,7 +242,6 @@ def _build_graph(invoke, seed):
     post('build_projects', req('build_projects'))
     post('swarm_sessions', req('swarm_sessions'))
     post('swarm_starts', req('swarm_starts'))
-    post('pipelines', req('pipelines'))
     post('agent_telemetry_runs', req('agent_telemetry_runs'))
     post('pipeline2_pipelines', req('pipeline2_pipelines'))
 
@@ -251,7 +253,6 @@ def _build_graph(invoke, seed):
                                       run_fk=ids['agent_telemetry_runs']))
 
     # Two levels down.
-    post('epics', dict(req('epics'), category_fk=ids['categories']))
     post('test_plans', dict(req('test_plans'), category_fk=ids['categories']))
     post('test_cases', dict(req('test_cases'), category_fk=ids['categories']))
     post('recurring_tasks', dict(req('recurring_tasks'), area_fk=ids['areas']))
@@ -366,7 +367,7 @@ def _value(conn, table, row_id, column):
 @pytest.mark.parametrize('triple', TRIPLES, ids=[_tid(t) for t in TRIPLES])
 def test_post_naming_a_victim_parent_is_refused(triple, victim_graph,
                                                 attacker_graph, db_connection):
-    """50 cases (four of them #3337's, two of them req #3369's, one req #3202's,
+    """40 cases (four of them #3337's, two of them req #3369's, one req #3202's,
     two more #3350's, against a
     victim-owned pipeline2_pipelines -> pipeline2_epics chain built by
     `_build_graph`). The attacker's own, otherwise-valid row, aimed at the
@@ -436,7 +437,7 @@ def test_put_repointing_at_a_victim_parent_is_refused(triple, victim_graph,
 @pytest.mark.parametrize('triple', TRIPLES, ids=[_tid(t) for t in TRIPLES])
 def test_no_divergent_spelling_of_a_victim_parent_lands_on_any_column(
         triple, victim_graph, attacker_graph, db_connection):
-    """The #3122 value-divergence payloads, applied to all 50 columns.
+    """The #3122 value-divergence payloads, applied to all 40 columns.
 
     Each is a spelling MySQL reads as the victim's id and Python does not. Any
     one accepted is the same cross-tenant write through a different door, so the

--- a/tests/test_junction_scoping.py
+++ b/tests/test_junction_scoping.py
@@ -11,15 +11,15 @@ gate, and `POST` injected one into their plan.
 
 **Retargeted to the Pipeline 2.0 junctions by req #3356**, which dropped the 1.0
 plan layer this file was written against. The worked example moves from
-`pipeline_step_deps` / `pipeline_step_requirements` to `pipeline2_step_deps` /
-`pipeline2_step_requirements`; the rule under test, the attacks, and every
+`pipeline_step_deps` / `pipeline_step_requirements` to `pipeline_step_deps` /
+`pipeline_step_requirements`; the rule under test, the attacks, and every
 assertion are unchanged. Deleting the file instead would have left the 2.0
 junctions with unit-tier registry checks and NO end-to-end cross-tenant coverage
 anywhere — the tier this file exists to be.
 
 Two 1.0-only shapes did not survive the move, both because 2.0 moved the time
-gate off the edge and onto `pipeline2_steps.not_before`:
-`pipeline2_step_deps.dep_step_fk` is NOT NULL, so there is no wall-clock gate row
+gate off the edge and onto `pipeline_steps.not_before`:
+`pipeline_step_deps.dep_step_fk` is NOT NULL, so there is no wall-clock gate row
 with a NULL verify column (that rule keeps its unit-tier case,
 `test_unit_junction_scoping.py::test_null_verify_columns_are_skipped_not_refused`),
 and there is no innocuous `time_at` column to mutate, so the PUT cases move the
@@ -78,16 +78,16 @@ def _teardown_plan(cur, creator):
 
     Deps before steps (`dep_step_fk` is RESTRICT), links before requirements
     (`requirement_fk` is RESTRICT), epics before categories
-    (`pipeline2_epics.category_fk` is RESTRICT). Anything else and the DELETE
+    (`epics.category_fk` is RESTRICT). Anything else and the DELETE
     fails on a constraint rather than cleaning up.
     """
-    cur.execute("DELETE FROM pipeline2_step_deps WHERE step_fk IN "
-                "(SELECT id FROM pipeline2_steps WHERE creator_fk = %s)", (creator,))
-    cur.execute("DELETE FROM pipeline2_step_requirements WHERE step_fk IN "
-                "(SELECT id FROM pipeline2_steps WHERE creator_fk = %s)", (creator,))
-    cur.execute("DELETE FROM pipeline2_steps WHERE creator_fk = %s", (creator,))
-    cur.execute("DELETE FROM pipeline2_epics WHERE creator_fk = %s", (creator,))
-    cur.execute("DELETE FROM pipeline2_pipelines WHERE creator_fk = %s", (creator,))
+    cur.execute("DELETE FROM pipeline_step_deps WHERE step_fk IN "
+                "(SELECT id FROM pipeline_steps WHERE creator_fk = %s)", (creator,))
+    cur.execute("DELETE FROM pipeline_step_requirements WHERE step_fk IN "
+                "(SELECT id FROM pipeline_steps WHERE creator_fk = %s)", (creator,))
+    cur.execute("DELETE FROM pipeline_steps WHERE creator_fk = %s", (creator,))
+    cur.execute("DELETE FROM epics WHERE creator_fk = %s", (creator,))
+    cur.execute("DELETE FROM pipelines WHERE creator_fk = %s", (creator,))
     cur.execute("DELETE FROM requirements WHERE creator_fk = %s", (creator,))
     cur.execute("DELETE FROM categories WHERE creator_fk = %s", (creator,))
     cur.execute("DELETE FROM projects WHERE creator_fk = %s", (creator,))
@@ -115,7 +115,7 @@ def _build_plan(post, label):
     Built through the REST API rather than raw SQL on purpose: it is simultaneously
     the regression guard that an OWNER can still create every one of these rows.
 
-    THREE steps, not two: `pipeline2_step_deps` is `UNIQUE (step_fk,
+    THREE steps, not two: `pipeline_step_deps` is `UNIQUE (step_fk,
     dep_step_fk)`, and several owner-side cases create a spare edge that must not
     collide with the fixture's own. `step_c` is that spare target and carries no
     edge of its own.
@@ -131,21 +131,21 @@ def _build_plan(post, label):
     assert resp['statusCode'] == 200
     ids['category'] = extract_id(resp)
 
-    resp = post('/darwin_dev/pipeline2_pipelines', {'title': f'{label} plan',
+    resp = post('/darwin_dev/pipelines', {'title': f'{label} plan',
                                                     'pipeline_status': 'draft'})
     assert resp['statusCode'] == 200, f'{label} pipeline POST: {resp}'
     ids['pipeline'] = extract_id(resp)
 
     # 2.0 containment: a step belongs to an epic, and the epic to the plan. There
     # is no `pipeline_fk` on a step — the plan is derived through the epic.
-    resp = post('/darwin_dev/pipeline2_epics',
+    resp = post('/darwin_dev/epics',
                 {'pipeline_fk': ids['pipeline'], 'title': f'{label} epic',
                  'category_fk': ids['category']})
     assert resp['statusCode'] == 200, f'{label} epic POST: {resp}'
     ids['epic'] = extract_id(resp)
 
     for key in ('step_a', 'step_b', 'step_c'):
-        resp = post('/darwin_dev/pipeline2_steps',
+        resp = post('/darwin_dev/pipeline_steps',
                     {'epic_fk': ids['epic'], 'title': f'{label} {key}',
                      'run': 'auto'})
         assert resp['statusCode'] == 200, f'{label} {key} POST: {resp}'
@@ -153,7 +153,7 @@ def _build_plan(post, label):
 
     # step_b waits for step_a. A surrogate-id junction row — the shape req #3111
     # flagged, and the one an attacker could address directly.
-    resp = post('/darwin_dev/pipeline2_step_deps',
+    resp = post('/darwin_dev/pipeline_step_deps',
                 {'step_fk': ids['step_b'], 'dep_step_fk': ids['step_a']})
     assert resp['statusCode'] == 200, f'{label} dep POST: {resp}'
     ids['dep'] = extract_id(resp)
@@ -167,7 +167,7 @@ def _build_plan(post, label):
 
     # PK is `requirement_fk` alone and there is no `id` column, so `rest_post`
     # skips the read-back: 201 with no body.
-    resp = post('/darwin_dev/pipeline2_step_requirements',
+    resp = post('/darwin_dev/pipeline_step_requirements',
                 {'step_fk': ids['step_a'], 'requirement_fk': ids['requirement']})
     assert resp['statusCode'] in (200, 201), f'{label} link POST: {resp}'
     return ids
@@ -206,7 +206,7 @@ def _rows(response):
 
 def _dep_row(conn, dep_id):
     with conn.cursor() as cur:
-        cur.execute("SELECT step_fk, dep_step_fk FROM pipeline2_step_deps WHERE id = %s",
+        cur.execute("SELECT step_fk, dep_step_fk FROM pipeline_step_deps WHERE id = %s",
                     (dep_id,))
         return cur.fetchone()
 
@@ -227,7 +227,7 @@ def test_the_victims_rows_really_exist(db_connection, victim_plan):
     """Otherwise every 404 in this file would pass for the wrong reason."""
     assert _dep_row(db_connection, victim_plan['dep']) is not None
     assert _count(db_connection,
-                  "SELECT COUNT(*) AS n FROM pipeline2_step_requirements "
+                  "SELECT COUNT(*) AS n FROM pipeline_step_requirements "
                   "WHERE step_fk = %s AND requirement_fk = %s",
                   (victim_plan['step_a'], victim_plan['requirement'])) == 1
 
@@ -237,35 +237,35 @@ def test_the_victims_rows_really_exist(db_connection, victim_plan):
 # ---------------------------------------------------------------------------
 
 def test_list_of_all_edges_excludes_another_users(intruder, victim_plan, intruder_plan):
-    """`GET /pipeline2_step_deps` with no filter returned EVERY user's edges."""
-    ids = {str(row['id']) for row in _rows(intruder('GET', '/darwin_dev/pipeline2_step_deps'))}
+    """`GET /pipeline_step_deps` with no filter returned EVERY user's edges."""
+    ids = {str(row['id']) for row in _rows(intruder('GET', '/darwin_dev/pipeline_step_deps'))}
     assert str(victim_plan['dep']) not in ids
     assert str(intruder_plan['dep']) in ids      # and the intruder still sees their own
 
 
 def test_edge_by_id_is_not_readable_by_another_user(intruder, victim_plan):
     """The addressability req #3111 flagged: GET by the edge's surrogate id."""
-    resp = intruder('GET', '/darwin_dev/pipeline2_step_deps',
+    resp = intruder('GET', '/darwin_dev/pipeline_step_deps',
                     query={'id': str(victim_plan['dep'])})
     assert resp['statusCode'] == 404
 
 
 def test_edges_by_foreign_step_fk_are_not_readable(intruder, victim_plan):
-    resp = intruder('GET', '/darwin_dev/pipeline2_step_deps',
+    resp = intruder('GET', '/darwin_dev/pipeline_step_deps',
                     query={'step_fk': str(victim_plan['step_b'])})
     assert resp['statusCode'] == 404
 
 
 def test_requirement_links_of_a_foreign_step_are_not_readable(intruder, victim_plan):
     """The composite-PK junction leaks the same way, id column or not."""
-    resp = intruder('GET', '/darwin_dev/pipeline2_step_requirements',
+    resp = intruder('GET', '/darwin_dev/pipeline_step_requirements',
                     query={'step_fk': str(victim_plan['step_a'])})
     assert resp['statusCode'] == 404
 
 
 def test_the_owner_can_still_read_their_own_edge(invoke, victim_plan):
     """The fix must narrow to the owner, not past them."""
-    resp = invoke('GET', '/darwin_dev/pipeline2_step_deps',
+    resp = invoke('GET', '/darwin_dev/pipeline_step_deps',
                   query={'id': str(victim_plan['dep'])})
     assert resp['statusCode'] == 200
     rows = _rows(resp)
@@ -274,7 +274,7 @@ def test_the_owner_can_still_read_their_own_edge(invoke, victim_plan):
 
 
 def test_the_owner_can_still_read_their_own_requirement_links(invoke, victim_plan):
-    resp = invoke('GET', '/darwin_dev/pipeline2_step_requirements',
+    resp = invoke('GET', '/darwin_dev/pipeline_step_requirements',
                   query={'step_fk': str(victim_plan['step_a'])})
     assert resp['statusCode'] == 200
     assert len(_rows(resp)) == 1
@@ -288,25 +288,25 @@ def test_every_edge_on_an_owned_step_is_returned_not_just_the_scope_column(
     `time_at` set) and proved the read did not filter it away — a
     `dep_step_fk IN (...)` predicate would have hidden every time gate in the
     plan, and an ungated-looking step gets LAUNCHED. 2.0 moved the time gate onto
-    `pipeline2_steps.not_before`, so `dep_step_fk` is NOT NULL and there is no
+    `pipeline_steps.not_before`, so `dep_step_fk` is NOT NULL and there is no
     such row to plant. What survives, and is asserted here, is the general
     property that only the SCOPE column narrows a read: a second edge on the same
     step comes back too.
     """
-    resp = invoke('POST', '/darwin_dev/pipeline2_step_deps',
+    resp = invoke('POST', '/darwin_dev/pipeline_step_deps',
                   body={'step_fk': victim_plan['step_b'],
                         'dep_step_fk': victim_plan['step_c']})
     assert resp['statusCode'] == 200
     extra = extract_id(resp)
     try:
-        rows = _rows(invoke('GET', '/darwin_dev/pipeline2_step_deps',
+        rows = _rows(invoke('GET', '/darwin_dev/pipeline_step_deps',
                             query={'step_fk': str(victim_plan['step_b'])}))
         returned = {str(row['id']) for row in rows}
         assert str(extra) in returned
         assert str(victim_plan['dep']) in returned
     finally:
         with db_connection.cursor() as cur:
-            cur.execute("DELETE FROM pipeline2_step_deps WHERE id = %s", (extra,))
+            cur.execute("DELETE FROM pipeline_step_deps WHERE id = %s", (extra,))
         db_connection.commit()
 
 
@@ -314,7 +314,7 @@ def test_unauthenticated_access_to_a_junction_is_403(victim_plan):
     """With no identity there is nothing to derive scoping from, so refuse."""
     from handler import lambda_handler
     resp = lambda_handler({
-        'httpMethod': 'GET', 'path': '/darwin_dev/pipeline2_step_deps',
+        'httpMethod': 'GET', 'path': '/darwin_dev/pipeline_step_deps',
         'queryStringParameters': None, 'body': None, 'requestContext': {}}, {})
     assert resp['statusCode'] == 403
 
@@ -327,7 +327,7 @@ def test_put_cannot_repoint_another_users_edge(intruder, victim_plan,
                                                intruder_plan, db_connection):
     """Re-pointing an edge silently rewires another user's execution order."""
     before = _dep_row(db_connection, victim_plan['dep'])
-    resp = intruder('PUT', '/darwin_dev/pipeline2_step_deps',
+    resp = intruder('PUT', '/darwin_dev/pipeline_step_deps',
                     body=[{'id': str(victim_plan['dep']),
                            'dep_step_fk': str(intruder_plan['step_c'])}])
     assert resp['statusCode'] == 204            # matched nothing
@@ -343,7 +343,7 @@ def test_bulk_put_mixing_own_and_foreign_edges_only_touches_own(
     the scoping predicate, which is exactly what is under test here.
     """
     victim_before = _dep_row(db_connection, victim_plan['dep'])
-    resp = intruder('PUT', '/darwin_dev/pipeline2_step_deps', body=[
+    resp = intruder('PUT', '/darwin_dev/pipeline_step_deps', body=[
         {'id': str(intruder_plan['dep']),
          'dep_step_fk': str(intruder_plan['step_c'])},
         {'id': str(victim_plan['dep']),
@@ -352,26 +352,26 @@ def test_bulk_put_mixing_own_and_foreign_edges_only_touches_own(
     assert resp['statusCode'] in (200, 204)
     assert _dep_row(db_connection, victim_plan['dep']) == victim_before
     with db_connection.cursor() as cur:
-        cur.execute("SELECT dep_step_fk FROM pipeline2_step_deps WHERE id = %s",
+        cur.execute("SELECT dep_step_fk FROM pipeline_step_deps WHERE id = %s",
                     (intruder_plan['dep'],))
         # the intruder's own row DID update
         assert str(cur.fetchone()['dep_step_fk']) == str(intruder_plan['step_c'])
         # put it back: later cases assert on this edge's shape
-        cur.execute("UPDATE pipeline2_step_deps SET dep_step_fk = %s WHERE id = %s",
+        cur.execute("UPDATE pipeline_step_deps SET dep_step_fk = %s WHERE id = %s",
                     (intruder_plan['step_a'], intruder_plan['dep']))
     db_connection.commit()
 
 
 def test_the_owner_can_still_update_their_own_edge(invoke, victim_plan, db_connection):
-    resp = invoke('PUT', '/darwin_dev/pipeline2_step_deps',
+    resp = invoke('PUT', '/darwin_dev/pipeline_step_deps',
                   body=[{'id': str(victim_plan['dep']),
                          'dep_step_fk': str(victim_plan['step_c'])}])
     assert resp['statusCode'] == 200
     with db_connection.cursor() as cur:
-        cur.execute("SELECT dep_step_fk FROM pipeline2_step_deps WHERE id = %s",
+        cur.execute("SELECT dep_step_fk FROM pipeline_step_deps WHERE id = %s",
                     (victim_plan['dep'],))
         assert str(cur.fetchone()['dep_step_fk']) == str(victim_plan['step_c'])
-        cur.execute("UPDATE pipeline2_step_deps SET dep_step_fk = %s WHERE id = %s",
+        cur.execute("UPDATE pipeline_step_deps SET dep_step_fk = %s WHERE id = %s",
                     (victim_plan['step_a'], victim_plan['dep']))
     db_connection.commit()
 
@@ -383,7 +383,7 @@ def test_the_owner_can_still_update_their_own_edge(invoke, victim_plan, db_conne
 def test_delete_cannot_remove_another_users_edge_by_id(intruder, victim_plan,
                                                        db_connection):
     """Deleting a gate makes the step eligible — it gets LAUNCHED, not just edited."""
-    resp = intruder('DELETE', '/darwin_dev/pipeline2_step_deps',
+    resp = intruder('DELETE', '/darwin_dev/pipeline_step_deps',
                     body={'id': str(victim_plan['dep'])})
     assert resp['statusCode'] == 404
     assert _dep_row(db_connection, victim_plan['dep']) is not None
@@ -392,29 +392,29 @@ def test_delete_cannot_remove_another_users_edge_by_id(intruder, victim_plan,
 def test_delete_cannot_strip_a_foreign_steps_whole_gate(intruder, victim_plan,
                                                         db_connection):
     """`{"step_fk": N}` is the shape `set_step_deps` uses to clear a gate."""
-    resp = intruder('DELETE', '/darwin_dev/pipeline2_step_deps',
+    resp = intruder('DELETE', '/darwin_dev/pipeline_step_deps',
                     body={'step_fk': str(victim_plan['step_b'])})
     assert resp['statusCode'] == 404
     assert _count(db_connection,
-                  "SELECT COUNT(*) AS n FROM pipeline2_step_deps WHERE step_fk = %s",
+                  "SELECT COUNT(*) AS n FROM pipeline_step_deps WHERE step_fk = %s",
                   (victim_plan['step_b'],)) == 1
 
 
 def test_delete_cannot_unlink_a_foreign_steps_requirement(intruder, victim_plan,
                                                           db_connection):
-    resp = intruder('DELETE', '/darwin_dev/pipeline2_step_requirements',
+    resp = intruder('DELETE', '/darwin_dev/pipeline_step_requirements',
                     body={'step_fk': str(victim_plan['step_a']),
                           'requirement_fk': str(victim_plan['requirement'])})
     assert resp['statusCode'] == 404
     assert _count(db_connection,
-                  "SELECT COUNT(*) AS n FROM pipeline2_step_requirements "
+                  "SELECT COUNT(*) AS n FROM pipeline_step_requirements "
                   "WHERE step_fk = %s AND requirement_fk = %s",
                   (victim_plan['step_a'], victim_plan['requirement'])) == 1
 
 
 def test_bulk_delete_cannot_remove_another_users_edge(intruder, victim_plan,
                                                       db_connection):
-    resp = intruder('DELETE', '/darwin_dev/pipeline2_step_deps',
+    resp = intruder('DELETE', '/darwin_dev/pipeline_step_deps',
                     body=[{'id': str(victim_plan['dep'])}])
     assert resp['statusCode'] == 404
     assert _dep_row(db_connection, victim_plan['dep']) is not None
@@ -422,12 +422,12 @@ def test_bulk_delete_cannot_remove_another_users_edge(intruder, victim_plan,
 
 def test_the_owner_can_still_delete_their_own_edge(invoke, victim_plan, db_connection):
     """Create-and-remove, so the fixture's edge survives for the tests after this."""
-    resp = invoke('POST', '/darwin_dev/pipeline2_step_deps',
+    resp = invoke('POST', '/darwin_dev/pipeline_step_deps',
                   body={'step_fk': victim_plan['step_a'],
                         'dep_step_fk': victim_plan['step_c']})
     assert resp['statusCode'] == 200
     throwaway = extract_id(resp)
-    assert invoke('DELETE', '/darwin_dev/pipeline2_step_deps',
+    assert invoke('DELETE', '/darwin_dev/pipeline_step_deps',
                   body={'id': str(throwaway)})['statusCode'] == 200
     assert _dep_row(db_connection, throwaway) is None
 
@@ -440,14 +440,14 @@ def test_post_cannot_add_an_edge_to_a_foreign_step(intruder, victim_plan,
                                                    db_connection):
     """Injecting a gate into somebody else's plan stalls their step indefinitely."""
     before = _count(db_connection,
-                    "SELECT COUNT(*) AS n FROM pipeline2_step_deps WHERE step_fk = %s",
+                    "SELECT COUNT(*) AS n FROM pipeline_step_deps WHERE step_fk = %s",
                     (victim_plan['step_a'],))
-    resp = intruder('POST', '/darwin_dev/pipeline2_step_deps',
+    resp = intruder('POST', '/darwin_dev/pipeline_step_deps',
                     body={'step_fk': str(victim_plan['step_a']),
                           'dep_step_fk': str(victim_plan['step_b'])})
     assert resp['statusCode'] == 403
     assert _count(db_connection,
-                  "SELECT COUNT(*) AS n FROM pipeline2_step_deps WHERE step_fk = %s",
+                  "SELECT COUNT(*) AS n FROM pipeline_step_deps WHERE step_fk = %s",
                   (victim_plan['step_a'],)) == before
 
 
@@ -459,35 +459,35 @@ def test_post_cannot_point_an_owned_edge_at_a_foreign_step(intruder, victim_plan
     step permanently undeletable: a denial of service on their plan, mounted from
     entirely inside the attacker's own pipeline.
     """
-    resp = intruder('POST', '/darwin_dev/pipeline2_step_deps',
+    resp = intruder('POST', '/darwin_dev/pipeline_step_deps',
                     body={'step_fk': str(intruder_plan['step_a']),
                           'dep_step_fk': str(victim_plan['step_b'])})
     assert resp['statusCode'] == 403
     assert _count(db_connection,
-                  "SELECT COUNT(*) AS n FROM pipeline2_step_deps WHERE dep_step_fk = %s",
+                  "SELECT COUNT(*) AS n FROM pipeline_step_deps WHERE dep_step_fk = %s",
                   (victim_plan['step_b'],)) == 0
 
 
 def test_post_cannot_link_a_requirement_to_a_foreign_step(intruder, victim_plan,
                                                           db_connection):
-    resp = intruder('POST', '/darwin_dev/pipeline2_step_requirements',
+    resp = intruder('POST', '/darwin_dev/pipeline_step_requirements',
                     body={'step_fk': str(victim_plan['step_a']),
                           'requirement_fk': str(victim_plan['requirement'])})
     assert resp['statusCode'] == 403
     assert _count(db_connection,
-                  "SELECT COUNT(*) AS n FROM pipeline2_step_requirements WHERE step_fk = %s",
+                  "SELECT COUNT(*) AS n FROM pipeline_step_requirements WHERE step_fk = %s",
                   (victim_plan['step_a'],)) == 1
 
 
 def test_post_cannot_pull_a_foreign_requirement_into_an_owned_step(
         intruder, victim_plan, intruder_plan, db_connection):
     """`requirement_fk` is RESTRICT — this would block the victim's own delete."""
-    resp = intruder('POST', '/darwin_dev/pipeline2_step_requirements',
+    resp = intruder('POST', '/darwin_dev/pipeline_step_requirements',
                     body={'step_fk': str(intruder_plan['step_b']),
                           'requirement_fk': str(victim_plan['requirement'])})
     assert resp['statusCode'] == 403
     assert _count(db_connection,
-                  "SELECT COUNT(*) AS n FROM pipeline2_step_requirements "
+                  "SELECT COUNT(*) AS n FROM pipeline_step_requirements "
                   "WHERE requirement_fk = %s", (victim_plan['requirement'],)) == 1
 
 
@@ -495,9 +495,9 @@ def test_bulk_post_refuses_the_whole_batch_for_one_foreign_row(
         intruder, victim_plan, intruder_plan, db_connection):
     """One multi-value INSERT: a partial accept would be worse than a refusal."""
     before = _count(db_connection,
-                    "SELECT COUNT(*) AS n FROM pipeline2_step_deps WHERE step_fk = %s",
+                    "SELECT COUNT(*) AS n FROM pipeline_step_deps WHERE step_fk = %s",
                     (intruder_plan['step_a'],))
-    resp = intruder('POST', '/darwin_dev/pipeline2_step_deps', body=[
+    resp = intruder('POST', '/darwin_dev/pipeline_step_deps', body=[
         {'step_fk': str(intruder_plan['step_a']),
          'dep_step_fk': str(intruder_plan['step_c'])},
         {'step_fk': str(victim_plan['step_a']),
@@ -505,14 +505,14 @@ def test_bulk_post_refuses_the_whole_batch_for_one_foreign_row(
     ])
     assert resp['statusCode'] == 403
     assert _count(db_connection,
-                  "SELECT COUNT(*) AS n FROM pipeline2_step_deps WHERE step_fk = %s",
+                  "SELECT COUNT(*) AS n FROM pipeline_step_deps WHERE step_fk = %s",
                   (intruder_plan['step_a'],)) == before
 
 
 def test_post_without_the_scope_column_is_400(intruder, victim_plan):
     """Ownership cannot be established — but that is a malformed body, not a
     credentials problem, so it must not read as 403."""
-    resp = intruder('POST', '/darwin_dev/pipeline2_step_deps',
+    resp = intruder('POST', '/darwin_dev/pipeline_step_deps',
                     body={'dep_step_fk': str(victim_plan['step_a'])})
     assert resp['statusCode'] == 400
 
@@ -531,12 +531,12 @@ def test_a_nonexistent_step_is_still_the_foreign_key_409_not_a_403(intruder,
     FK typo a confidently wrong explanation: "references a row another creator
     owns", of a row that does not exist.
     """
-    foreign = intruder('POST', '/darwin_dev/pipeline2_step_deps',
+    foreign = intruder('POST', '/darwin_dev/pipeline_step_deps',
                        body={'step_fk': str(victim_plan['step_a']),
                              'dep_step_fk': str(intruder_plan['step_c'])})
     assert foreign['statusCode'] == 403
 
-    missing = intruder('POST', '/darwin_dev/pipeline2_step_deps',
+    missing = intruder('POST', '/darwin_dev/pipeline_step_deps',
                        body={'step_fk': '999999999',
                              'dep_step_fk': str(intruder_plan['step_c'])})
     assert missing['statusCode'] == 409
@@ -545,7 +545,7 @@ def test_a_nonexistent_step_is_still_the_foreign_key_409_not_a_403(intruder,
 
 def test_the_owner_can_still_create_edges_and_links(invoke, victim_plan, db_connection):
     """The whole owner-side write path, after every refusal above."""
-    resp = invoke('POST', '/darwin_dev/pipeline2_step_deps',
+    resp = invoke('POST', '/darwin_dev/pipeline_step_deps',
                   body={'step_fk': victim_plan['step_a'],
                         'dep_step_fk': victim_plan['step_b']})
     assert resp['statusCode'] == 200
@@ -554,7 +554,7 @@ def test_the_owner_can_still_create_edges_and_links(invoke, victim_plan, db_conn
         assert _dep_row(db_connection, new_dep) is not None
     finally:
         with db_connection.cursor() as cur:
-            cur.execute("DELETE FROM pipeline2_step_deps WHERE id = %s", (new_dep,))
+            cur.execute("DELETE FROM pipeline_step_deps WHERE id = %s", (new_dep,))
         db_connection.commit()
 
 
@@ -613,12 +613,12 @@ def test_put_cannot_move_an_owned_edge_onto_a_foreign_step(
     on a dependency they never created — and per the orchestration doctrine an
     unexpected gate means their step is not launched.
     """
-    resp = intruder('PUT', '/darwin_dev/pipeline2_step_deps',
+    resp = intruder('PUT', '/darwin_dev/pipeline_step_deps',
                     body=[{'id': str(intruder_plan['dep']),
                            'step_fk': str(victim_plan['step_a'])}])
     assert resp['statusCode'] == 403
     with db_connection.cursor() as cur:
-        cur.execute("SELECT step_fk FROM pipeline2_step_deps WHERE id = %s",
+        cur.execute("SELECT step_fk FROM pipeline_step_deps WHERE id = %s",
                     (intruder_plan['dep'],))
         assert str(cur.fetchone()['step_fk']) == str(intruder_plan['step_b'])
 
@@ -630,26 +630,26 @@ def test_put_cannot_repoint_an_owned_edge_at_a_foreign_step(
     `dep_step_fk` is ON DELETE RESTRICT: an edge pointing at the victim's step
     makes that step undeletable and unmergeable, from inside the attacker's plan.
     """
-    resp = intruder('PUT', '/darwin_dev/pipeline2_step_deps',
+    resp = intruder('PUT', '/darwin_dev/pipeline_step_deps',
                     body=[{'id': str(intruder_plan['dep']),
                            'dep_step_fk': str(victim_plan['step_b'])}])
     assert resp['statusCode'] == 403
     assert _count(db_connection,
-                  "SELECT COUNT(*) AS n FROM pipeline2_step_deps WHERE dep_step_fk = %s",
+                  "SELECT COUNT(*) AS n FROM pipeline_step_deps WHERE dep_step_fk = %s",
                   (victim_plan['step_b'],)) == 0
 
 
 def test_bulk_put_cannot_smuggle_a_foreign_parent_in_one_row(
         intruder, victim_plan, intruder_plan, db_connection):
     """One CASE statement covers every row, so one bad row refuses the batch."""
-    resp = intruder('PUT', '/darwin_dev/pipeline2_step_deps', body=[
+    resp = intruder('PUT', '/darwin_dev/pipeline_step_deps', body=[
         {'id': str(intruder_plan['dep']),
          'dep_step_fk': str(intruder_plan['step_c'])},
         {'id': str(intruder_plan['dep']), 'step_fk': str(victim_plan['step_a'])},
     ])
     assert resp['statusCode'] == 403
     with db_connection.cursor() as cur:
-        cur.execute("SELECT step_fk FROM pipeline2_step_deps WHERE id = %s",
+        cur.execute("SELECT step_fk FROM pipeline_step_deps WHERE id = %s",
                     (intruder_plan['dep'],))
         assert str(cur.fetchone()['step_fk']) == str(intruder_plan['step_b'])
 
@@ -657,22 +657,22 @@ def test_bulk_put_cannot_smuggle_a_foreign_parent_in_one_row(
 def test_the_owner_can_still_move_their_own_edge_between_their_own_steps(
         invoke, victim_plan, db_connection):
     """Rewriting the scope column is legitimate — within your own rows."""
-    resp = invoke('POST', '/darwin_dev/pipeline2_step_deps',
+    resp = invoke('POST', '/darwin_dev/pipeline_step_deps',
                   body={'step_fk': victim_plan['step_a'],
                         'dep_step_fk': victim_plan['step_c']})
     assert resp['statusCode'] == 200
     moved = extract_id(resp)
     try:
-        assert invoke('PUT', '/darwin_dev/pipeline2_step_deps',
+        assert invoke('PUT', '/darwin_dev/pipeline_step_deps',
                       body=[{'id': str(moved),
                              'step_fk': str(victim_plan['step_b'])}])['statusCode'] == 200
         with db_connection.cursor() as cur:
-            cur.execute("SELECT step_fk FROM pipeline2_step_deps WHERE id = %s",
+            cur.execute("SELECT step_fk FROM pipeline_step_deps WHERE id = %s",
                         (moved,))
             assert str(cur.fetchone()['step_fk']) == str(victim_plan['step_b'])
     finally:
         with db_connection.cursor() as cur:
-            cur.execute("DELETE FROM pipeline2_step_deps WHERE id = %s", (moved,))
+            cur.execute("DELETE FROM pipeline_step_deps WHERE id = %s", (moved,))
         db_connection.commit()
 
 
@@ -724,15 +724,15 @@ def test_delete_body_key_injection_cannot_cancel_the_scoping(
     pre-existing `creator_fk` scoping the same way, on every table.
     """
     before = _count(db_connection,
-                    "SELECT COUNT(*) AS n FROM pipeline2_step_deps WHERE step_fk = %s",
+                    "SELECT COUNT(*) AS n FROM pipeline_step_deps WHERE step_fk = %s",
                     (victim_plan['step_b'],))
     assert before == 1
 
-    resp = intruder('DELETE', '/darwin_dev/pipeline2_step_deps', body={
+    resp = intruder('DELETE', '/darwin_dev/pipeline_step_deps', body={
         f"id = 1 OR step_fk = {victim_plan['step_b']} OR id": '1'})
     assert resp['statusCode'] == 400
     assert _count(db_connection,
-                  "SELECT COUNT(*) AS n FROM pipeline2_step_deps WHERE step_fk = %s",
+                  "SELECT COUNT(*) AS n FROM pipeline_step_deps WHERE step_fk = %s",
                   (victim_plan['step_b'],)) == before
 
 
@@ -747,7 +747,7 @@ def test_delete_body_key_injection_cannot_cancel_creator_fk_scoping(
 
 
 def test_delete_rejects_an_unknown_column_rather_than_interpolating_it(intruder):
-    resp = intruder('DELETE', '/darwin_dev/pipeline2_step_deps',
+    resp = intruder('DELETE', '/darwin_dev/pipeline_step_deps',
                     body={'not_a_column': '1'})
     assert resp['statusCode'] == 400
 
@@ -755,12 +755,12 @@ def test_delete_rejects_an_unknown_column_rather_than_interpolating_it(intruder)
 def test_the_owner_can_still_delete_by_a_real_column(invoke, victim_plan,
                                                      db_connection):
     """Key validation must not break the legitimate multi-key delete."""
-    resp = invoke('POST', '/darwin_dev/pipeline2_step_deps',
+    resp = invoke('POST', '/darwin_dev/pipeline_step_deps',
                   body={'step_fk': victim_plan['step_a'],
                         'dep_step_fk': victim_plan['step_b']})
     assert resp['statusCode'] == 200
     made = extract_id(resp)
-    assert invoke('DELETE', '/darwin_dev/pipeline2_step_deps',
+    assert invoke('DELETE', '/darwin_dev/pipeline_step_deps',
                   body={'step_fk': str(victim_plan['step_a']),
                         'dep_step_fk': str(victim_plan['step_b'])})['statusCode'] == 200
     assert _dep_row(db_connection, made) is None

--- a/tests/test_junction_scoping.py
+++ b/tests/test_junction_scoping.py
@@ -5,9 +5,27 @@ plant real rows for a victim, drive the gateway as a second authenticated user,
 and prove the answer is 404 or 403 — never data, and never a write that lands.
 
 Every one of these FAILED before req #3122. The gateway had no scoping for these
-tables at all, so `GET /darwin_dev/pipeline_step_deps` returned every user's
-dependency edges, `PUT`/`DELETE` by id rewrote or removed another user's gate, and
-`POST` injected one into their plan.
+tables at all, so an unfiltered `GET` on a step-dependency table returned every
+user's dependency edges, `PUT`/`DELETE` by id rewrote or removed another user's
+gate, and `POST` injected one into their plan.
+
+**Retargeted to the Pipeline 2.0 junctions by req #3356**, which dropped the 1.0
+plan layer this file was written against. The worked example moves from
+`pipeline_step_deps` / `pipeline_step_requirements` to `pipeline2_step_deps` /
+`pipeline2_step_requirements`; the rule under test, the attacks, and every
+assertion are unchanged. Deleting the file instead would have left the 2.0
+junctions with unit-tier registry checks and NO end-to-end cross-tenant coverage
+anywhere — the tier this file exists to be.
+
+Two 1.0-only shapes did not survive the move, both because 2.0 moved the time
+gate off the edge and onto `pipeline2_steps.not_before`:
+`pipeline2_step_deps.dep_step_fk` is NOT NULL, so there is no wall-clock gate row
+with a NULL verify column (that rule keeps its unit-tier case,
+`test_unit_junction_scoping.py::test_null_verify_columns_are_skipped_not_refused`),
+and there is no innocuous `time_at` column to mutate, so the PUT cases move the
+edge's own `dep_step_fk` between owned steps instead. Each plan therefore builds
+THREE steps rather than two, because `UNIQUE (step_fk, dep_step_fk)` means a case
+that creates a spare edge needs a target the fixture edge is not already using.
 
 The victim-side tests interleaved through the file matter as much as the attacker
 ones: a scoping rule that also breaks the owner is not a fix. Each attacker
@@ -55,26 +73,32 @@ def intruder(intruder_fk, db_connection):
     _purge(db_connection, intruder_fk)
 
 
-def _purge(conn, creator):
-    """Tear a creator's pipeline/requirement graph down in FK-safe order.
+def _teardown_plan(cur, creator):
+    """The plan half of a creator's teardown, in FK-safe order.
 
     Deps before steps (`dep_step_fk` is RESTRICT), links before requirements
-    (`requirement_fk` is RESTRICT) — the two-phase teardown migration 076
-    documents. Anything else and the DELETE fails on a constraint rather than
-    cleaning up.
+    (`requirement_fk` is RESTRICT), epics before categories
+    (`pipeline2_epics.category_fk` is RESTRICT). Anything else and the DELETE
+    fails on a constraint rather than cleaning up.
     """
+    cur.execute("DELETE FROM pipeline2_step_deps WHERE step_fk IN "
+                "(SELECT id FROM pipeline2_steps WHERE creator_fk = %s)", (creator,))
+    cur.execute("DELETE FROM pipeline2_step_requirements WHERE step_fk IN "
+                "(SELECT id FROM pipeline2_steps WHERE creator_fk = %s)", (creator,))
+    cur.execute("DELETE FROM pipeline2_steps WHERE creator_fk = %s", (creator,))
+    cur.execute("DELETE FROM pipeline2_epics WHERE creator_fk = %s", (creator,))
+    cur.execute("DELETE FROM pipeline2_pipelines WHERE creator_fk = %s", (creator,))
+    cur.execute("DELETE FROM requirements WHERE creator_fk = %s", (creator,))
+    cur.execute("DELETE FROM categories WHERE creator_fk = %s", (creator,))
+    cur.execute("DELETE FROM projects WHERE creator_fk = %s", (creator,))
+
+
+def _purge(conn, creator):
+    """Tear a creator's plan/requirement graph down, then the profile itself."""
     import pymysql as _pymysql
     try:
         with conn.cursor() as cur:
-            cur.execute("DELETE FROM pipeline_step_deps WHERE step_fk IN "
-                        "(SELECT id FROM pipeline_steps WHERE creator_fk = %s)", (creator,))
-            cur.execute("DELETE FROM pipeline_step_requirements WHERE step_fk IN "
-                        "(SELECT id FROM pipeline_steps WHERE creator_fk = %s)", (creator,))
-            cur.execute("DELETE FROM pipeline_steps WHERE creator_fk = %s", (creator,))
-            cur.execute("DELETE FROM pipelines WHERE creator_fk = %s", (creator,))
-            cur.execute("DELETE FROM requirements WHERE creator_fk = %s", (creator,))
-            cur.execute("DELETE FROM categories WHERE creator_fk = %s", (creator,))
-            cur.execute("DELETE FROM projects WHERE creator_fk = %s", (creator,))
+            _teardown_plan(cur, creator)
             cur.execute("DELETE FROM profiles WHERE id = %s", (creator,))
         conn.commit()
     except _pymysql.MySQLError:
@@ -86,31 +110,17 @@ def _purge(conn, creator):
 # ---------------------------------------------------------------------------
 
 def _build_plan(post, label):
-    """pipeline -> 2 steps -> 1 dep edge -> project/category/requirement -> 1 link.
+    """project/category -> pipeline -> epic -> 3 steps -> 1 dep edge -> requirement -> 1 link.
 
     Built through the REST API rather than raw SQL on purpose: it is simultaneously
     the regression guard that an OWNER can still create every one of these rows.
+
+    THREE steps, not two: `pipeline2_step_deps` is `UNIQUE (step_fk,
+    dep_step_fk)`, and several owner-side cases create a spare edge that must not
+    collide with the fixture's own. `step_c` is that spare target and carries no
+    edge of its own.
     """
     ids = {}
-
-    resp = post('/darwin_dev/pipelines', {'title': f'{label} plan',
-                                          'pipeline_status': 'draft'})
-    assert resp['statusCode'] == 200, f'{label} pipeline POST: {resp}'
-    ids['pipeline'] = extract_id(resp)
-
-    for key in ('step_a', 'step_b'):
-        resp = post('/darwin_dev/pipeline_steps',
-                    {'pipeline_fk': ids['pipeline'], 'title': f'{label} {key}',
-                     'run': 'auto'})
-        assert resp['statusCode'] == 200, f'{label} {key} POST: {resp}'
-        ids[key] = extract_id(resp)
-
-    # step_b waits for step_a. A surrogate-id junction row — the shape req #3111
-    # flagged, and the one an attacker could address directly.
-    resp = post('/darwin_dev/pipeline_step_deps',
-                {'step_fk': ids['step_b'], 'dep_step_fk': ids['step_a']})
-    assert resp['statusCode'] == 200, f'{label} dep POST: {resp}'
-    ids['dep'] = extract_id(resp)
 
     resp = post('/darwin_dev/projects', {'project_name': f'{label} project'})
     assert resp['statusCode'] == 200
@@ -121,6 +131,33 @@ def _build_plan(post, label):
     assert resp['statusCode'] == 200
     ids['category'] = extract_id(resp)
 
+    resp = post('/darwin_dev/pipeline2_pipelines', {'title': f'{label} plan',
+                                                    'pipeline_status': 'draft'})
+    assert resp['statusCode'] == 200, f'{label} pipeline POST: {resp}'
+    ids['pipeline'] = extract_id(resp)
+
+    # 2.0 containment: a step belongs to an epic, and the epic to the plan. There
+    # is no `pipeline_fk` on a step — the plan is derived through the epic.
+    resp = post('/darwin_dev/pipeline2_epics',
+                {'pipeline_fk': ids['pipeline'], 'title': f'{label} epic',
+                 'category_fk': ids['category']})
+    assert resp['statusCode'] == 200, f'{label} epic POST: {resp}'
+    ids['epic'] = extract_id(resp)
+
+    for key in ('step_a', 'step_b', 'step_c'):
+        resp = post('/darwin_dev/pipeline2_steps',
+                    {'epic_fk': ids['epic'], 'title': f'{label} {key}',
+                     'run': 'auto'})
+        assert resp['statusCode'] == 200, f'{label} {key} POST: {resp}'
+        ids[key] = extract_id(resp)
+
+    # step_b waits for step_a. A surrogate-id junction row — the shape req #3111
+    # flagged, and the one an attacker could address directly.
+    resp = post('/darwin_dev/pipeline2_step_deps',
+                {'step_fk': ids['step_b'], 'dep_step_fk': ids['step_a']})
+    assert resp['statusCode'] == 200, f'{label} dep POST: {resp}'
+    ids['dep'] = extract_id(resp)
+
     resp = post('/darwin_dev/requirements',
                 {'title': f'{label} requirement', 'requirement_status': 'authoring',
                  'category_fk': ids['category'], 'coordination_type': 'implemented',
@@ -128,8 +165,9 @@ def _build_plan(post, label):
     assert resp['statusCode'] == 200
     ids['requirement'] = extract_id(resp)
 
-    # Composite-PK junction: 201 with no body (nothing to read back on).
-    resp = post('/darwin_dev/pipeline_step_requirements',
+    # PK is `requirement_fk` alone and there is no `id` column, so `rest_post`
+    # skips the read-back: 201 with no body.
+    resp = post('/darwin_dev/pipeline2_step_requirements',
                 {'step_fk': ids['step_a'], 'requirement_fk': ids['requirement']})
     assert resp['statusCode'] in (200, 201), f'{label} link POST: {resp}'
     return ids
@@ -142,15 +180,7 @@ def victim_plan(invoke, test_data, db_connection, creator_fk):
     import pymysql as _pymysql
     try:
         with db_connection.cursor() as cur:
-            cur.execute("DELETE FROM pipeline_step_deps WHERE step_fk IN "
-                        "(SELECT id FROM pipeline_steps WHERE creator_fk = %s)", (creator_fk,))
-            cur.execute("DELETE FROM pipeline_step_requirements WHERE step_fk IN "
-                        "(SELECT id FROM pipeline_steps WHERE creator_fk = %s)", (creator_fk,))
-            cur.execute("DELETE FROM pipeline_steps WHERE creator_fk = %s", (creator_fk,))
-            cur.execute("DELETE FROM pipelines WHERE creator_fk = %s", (creator_fk,))
-            cur.execute("DELETE FROM requirements WHERE creator_fk = %s", (creator_fk,))
-            cur.execute("DELETE FROM categories WHERE creator_fk = %s", (creator_fk,))
-            cur.execute("DELETE FROM projects WHERE creator_fk = %s", (creator_fk,))
+            _teardown_plan(cur, creator_fk)
         db_connection.commit()
     except _pymysql.MySQLError:
         db_connection.rollback()
@@ -176,7 +206,7 @@ def _rows(response):
 
 def _dep_row(conn, dep_id):
     with conn.cursor() as cur:
-        cur.execute("SELECT step_fk, dep_step_fk FROM pipeline_step_deps WHERE id = %s",
+        cur.execute("SELECT step_fk, dep_step_fk FROM pipeline2_step_deps WHERE id = %s",
                     (dep_id,))
         return cur.fetchone()
 
@@ -197,7 +227,7 @@ def test_the_victims_rows_really_exist(db_connection, victim_plan):
     """Otherwise every 404 in this file would pass for the wrong reason."""
     assert _dep_row(db_connection, victim_plan['dep']) is not None
     assert _count(db_connection,
-                  "SELECT COUNT(*) AS n FROM pipeline_step_requirements "
+                  "SELECT COUNT(*) AS n FROM pipeline2_step_requirements "
                   "WHERE step_fk = %s AND requirement_fk = %s",
                   (victim_plan['step_a'], victim_plan['requirement'])) == 1
 
@@ -207,35 +237,35 @@ def test_the_victims_rows_really_exist(db_connection, victim_plan):
 # ---------------------------------------------------------------------------
 
 def test_list_of_all_edges_excludes_another_users(intruder, victim_plan, intruder_plan):
-    """`GET /pipeline_step_deps` with no filter returned EVERY user's edges."""
-    ids = {str(row['id']) for row in _rows(intruder('GET', '/darwin_dev/pipeline_step_deps'))}
+    """`GET /pipeline2_step_deps` with no filter returned EVERY user's edges."""
+    ids = {str(row['id']) for row in _rows(intruder('GET', '/darwin_dev/pipeline2_step_deps'))}
     assert str(victim_plan['dep']) not in ids
     assert str(intruder_plan['dep']) in ids      # and the intruder still sees their own
 
 
 def test_edge_by_id_is_not_readable_by_another_user(intruder, victim_plan):
     """The addressability req #3111 flagged: GET by the edge's surrogate id."""
-    resp = intruder('GET', '/darwin_dev/pipeline_step_deps',
+    resp = intruder('GET', '/darwin_dev/pipeline2_step_deps',
                     query={'id': str(victim_plan['dep'])})
     assert resp['statusCode'] == 404
 
 
 def test_edges_by_foreign_step_fk_are_not_readable(intruder, victim_plan):
-    resp = intruder('GET', '/darwin_dev/pipeline_step_deps',
+    resp = intruder('GET', '/darwin_dev/pipeline2_step_deps',
                     query={'step_fk': str(victim_plan['step_b'])})
     assert resp['statusCode'] == 404
 
 
 def test_requirement_links_of_a_foreign_step_are_not_readable(intruder, victim_plan):
     """The composite-PK junction leaks the same way, id column or not."""
-    resp = intruder('GET', '/darwin_dev/pipeline_step_requirements',
+    resp = intruder('GET', '/darwin_dev/pipeline2_step_requirements',
                     query={'step_fk': str(victim_plan['step_a'])})
     assert resp['statusCode'] == 404
 
 
 def test_the_owner_can_still_read_their_own_edge(invoke, victim_plan):
     """The fix must narrow to the owner, not past them."""
-    resp = invoke('GET', '/darwin_dev/pipeline_step_deps',
+    resp = invoke('GET', '/darwin_dev/pipeline2_step_deps',
                   query={'id': str(victim_plan['dep'])})
     assert resp['statusCode'] == 200
     rows = _rows(resp)
@@ -244,32 +274,39 @@ def test_the_owner_can_still_read_their_own_edge(invoke, victim_plan):
 
 
 def test_the_owner_can_still_read_their_own_requirement_links(invoke, victim_plan):
-    resp = invoke('GET', '/darwin_dev/pipeline_step_requirements',
+    resp = invoke('GET', '/darwin_dev/pipeline2_step_requirements',
                   query={'step_fk': str(victim_plan['step_a'])})
     assert resp['statusCode'] == 200
     assert len(_rows(resp)) == 1
 
 
-def test_a_wall_clock_gate_row_survives_the_scoping(invoke, victim_plan, db_connection):
-    """`dep_step_fk` is NULL on a time gate; scoping must not filter those out.
+def test_every_edge_on_an_owned_step_is_returned_not_just_the_scope_column(
+        invoke, victim_plan, db_connection):
+    """`verify` columns are checked on INSERT only, never ANDed into a read.
 
-    This is why `verify` columns are checked on INSERT only and never ANDed into a
-    read predicate: `dep_step_fk IN (...)` would have hidden every wall-clock gate
-    in the plan, silently, and an ungated-looking step gets LAUNCHED.
+    The 1.0 form of this test planted a wall-clock gate row (`dep_step_fk` NULL,
+    `time_at` set) and proved the read did not filter it away — a
+    `dep_step_fk IN (...)` predicate would have hidden every time gate in the
+    plan, and an ungated-looking step gets LAUNCHED. 2.0 moved the time gate onto
+    `pipeline2_steps.not_before`, so `dep_step_fk` is NOT NULL and there is no
+    such row to plant. What survives, and is asserted here, is the general
+    property that only the SCOPE column narrows a read: a second edge on the same
+    step comes back too.
     """
-    resp = invoke('POST', '/darwin_dev/pipeline_step_deps',
-                  body={'step_fk': victim_plan['step_b'], 'dep_step_fk': 'NULL',
-                        'time_at': '2026-07-27 06:31:38'})
+    resp = invoke('POST', '/darwin_dev/pipeline2_step_deps',
+                  body={'step_fk': victim_plan['step_b'],
+                        'dep_step_fk': victim_plan['step_c']})
     assert resp['statusCode'] == 200
-    time_dep = extract_id(resp)
+    extra = extract_id(resp)
     try:
-        rows = _rows(invoke('GET', '/darwin_dev/pipeline_step_deps',
+        rows = _rows(invoke('GET', '/darwin_dev/pipeline2_step_deps',
                             query={'step_fk': str(victim_plan['step_b'])}))
-        assert str(time_dep) in {str(row['id']) for row in rows}
-        assert any(row['dep_step_fk'] is None for row in rows)
+        returned = {str(row['id']) for row in rows}
+        assert str(extra) in returned
+        assert str(victim_plan['dep']) in returned
     finally:
         with db_connection.cursor() as cur:
-            cur.execute("DELETE FROM pipeline_step_deps WHERE id = %s", (time_dep,))
+            cur.execute("DELETE FROM pipeline2_step_deps WHERE id = %s", (extra,))
         db_connection.commit()
 
 
@@ -277,7 +314,7 @@ def test_unauthenticated_access_to_a_junction_is_403(victim_plan):
     """With no identity there is nothing to derive scoping from, so refuse."""
     from handler import lambda_handler
     resp = lambda_handler({
-        'httpMethod': 'GET', 'path': '/darwin_dev/pipeline_step_deps',
+        'httpMethod': 'GET', 'path': '/darwin_dev/pipeline2_step_deps',
         'queryStringParameters': None, 'body': None, 'requestContext': {}}, {})
     assert resp['statusCode'] == 403
 
@@ -286,39 +323,56 @@ def test_unauthenticated_access_to_a_junction_is_403(victim_plan):
 # PUT — the unscoped `else` branch of rest_put
 # ---------------------------------------------------------------------------
 
-def test_put_cannot_repoint_another_users_edge(intruder, victim_plan, db_connection):
+def test_put_cannot_repoint_another_users_edge(intruder, victim_plan,
+                                               intruder_plan, db_connection):
     """Re-pointing an edge silently rewires another user's execution order."""
     before = _dep_row(db_connection, victim_plan['dep'])
-    resp = intruder('PUT', '/darwin_dev/pipeline_step_deps',
-                    body=[{'id': str(victim_plan['dep']), 'dep_step_fk': 'NULL'}])
+    resp = intruder('PUT', '/darwin_dev/pipeline2_step_deps',
+                    body=[{'id': str(victim_plan['dep']),
+                           'dep_step_fk': str(intruder_plan['step_c'])}])
     assert resp['statusCode'] == 204            # matched nothing
     assert _dep_row(db_connection, victim_plan['dep']) == before
 
 
 def test_bulk_put_mixing_own_and_foreign_edges_only_touches_own(
         intruder, victim_plan, intruder_plan, db_connection):
-    """The CASE-syntax path. A mixed batch must not carry the foreign row through."""
+    """The CASE-syntax path. A mixed batch must not carry the foreign row through.
+
+    Both rows name a step the INTRUDER owns, so the write guard has nothing to
+    refuse — the only thing that can keep the victim's row out of the statement is
+    the scoping predicate, which is exactly what is under test here.
+    """
     victim_before = _dep_row(db_connection, victim_plan['dep'])
-    resp = intruder('PUT', '/darwin_dev/pipeline_step_deps', body=[
-        {'id': str(intruder_plan['dep']), 'time_at': '2026-07-27 01:02:03'},
-        {'id': str(victim_plan['dep']), 'time_at': '2026-07-27 01:02:03'},
+    resp = intruder('PUT', '/darwin_dev/pipeline2_step_deps', body=[
+        {'id': str(intruder_plan['dep']),
+         'dep_step_fk': str(intruder_plan['step_c'])},
+        {'id': str(victim_plan['dep']),
+         'dep_step_fk': str(intruder_plan['step_c'])},
     ])
     assert resp['statusCode'] in (200, 204)
     assert _dep_row(db_connection, victim_plan['dep']) == victim_before
     with db_connection.cursor() as cur:
-        cur.execute("SELECT time_at FROM pipeline_step_deps WHERE id = %s",
+        cur.execute("SELECT dep_step_fk FROM pipeline2_step_deps WHERE id = %s",
                     (intruder_plan['dep'],))
-        assert cur.fetchone()['time_at'] is not None     # the intruder's own row DID update
+        # the intruder's own row DID update
+        assert str(cur.fetchone()['dep_step_fk']) == str(intruder_plan['step_c'])
+        # put it back: later cases assert on this edge's shape
+        cur.execute("UPDATE pipeline2_step_deps SET dep_step_fk = %s WHERE id = %s",
+                    (intruder_plan['step_a'], intruder_plan['dep']))
+    db_connection.commit()
 
 
 def test_the_owner_can_still_update_their_own_edge(invoke, victim_plan, db_connection):
-    resp = invoke('PUT', '/darwin_dev/pipeline_step_deps',
+    resp = invoke('PUT', '/darwin_dev/pipeline2_step_deps',
                   body=[{'id': str(victim_plan['dep']),
-                         'time_at': '2026-07-27 02:03:04'}])
+                         'dep_step_fk': str(victim_plan['step_c'])}])
     assert resp['statusCode'] == 200
     with db_connection.cursor() as cur:
-        cur.execute("UPDATE pipeline_step_deps SET time_at = NULL WHERE id = %s",
+        cur.execute("SELECT dep_step_fk FROM pipeline2_step_deps WHERE id = %s",
                     (victim_plan['dep'],))
+        assert str(cur.fetchone()['dep_step_fk']) == str(victim_plan['step_c'])
+        cur.execute("UPDATE pipeline2_step_deps SET dep_step_fk = %s WHERE id = %s",
+                    (victim_plan['step_a'], victim_plan['dep']))
     db_connection.commit()
 
 
@@ -329,7 +383,7 @@ def test_the_owner_can_still_update_their_own_edge(invoke, victim_plan, db_conne
 def test_delete_cannot_remove_another_users_edge_by_id(intruder, victim_plan,
                                                        db_connection):
     """Deleting a gate makes the step eligible — it gets LAUNCHED, not just edited."""
-    resp = intruder('DELETE', '/darwin_dev/pipeline_step_deps',
+    resp = intruder('DELETE', '/darwin_dev/pipeline2_step_deps',
                     body={'id': str(victim_plan['dep'])})
     assert resp['statusCode'] == 404
     assert _dep_row(db_connection, victim_plan['dep']) is not None
@@ -338,29 +392,29 @@ def test_delete_cannot_remove_another_users_edge_by_id(intruder, victim_plan,
 def test_delete_cannot_strip_a_foreign_steps_whole_gate(intruder, victim_plan,
                                                         db_connection):
     """`{"step_fk": N}` is the shape `set_step_deps` uses to clear a gate."""
-    resp = intruder('DELETE', '/darwin_dev/pipeline_step_deps',
+    resp = intruder('DELETE', '/darwin_dev/pipeline2_step_deps',
                     body={'step_fk': str(victim_plan['step_b'])})
     assert resp['statusCode'] == 404
     assert _count(db_connection,
-                  "SELECT COUNT(*) AS n FROM pipeline_step_deps WHERE step_fk = %s",
+                  "SELECT COUNT(*) AS n FROM pipeline2_step_deps WHERE step_fk = %s",
                   (victim_plan['step_b'],)) == 1
 
 
 def test_delete_cannot_unlink_a_foreign_steps_requirement(intruder, victim_plan,
                                                           db_connection):
-    resp = intruder('DELETE', '/darwin_dev/pipeline_step_requirements',
+    resp = intruder('DELETE', '/darwin_dev/pipeline2_step_requirements',
                     body={'step_fk': str(victim_plan['step_a']),
                           'requirement_fk': str(victim_plan['requirement'])})
     assert resp['statusCode'] == 404
     assert _count(db_connection,
-                  "SELECT COUNT(*) AS n FROM pipeline_step_requirements "
+                  "SELECT COUNT(*) AS n FROM pipeline2_step_requirements "
                   "WHERE step_fk = %s AND requirement_fk = %s",
                   (victim_plan['step_a'], victim_plan['requirement'])) == 1
 
 
 def test_bulk_delete_cannot_remove_another_users_edge(intruder, victim_plan,
                                                       db_connection):
-    resp = intruder('DELETE', '/darwin_dev/pipeline_step_deps',
+    resp = intruder('DELETE', '/darwin_dev/pipeline2_step_deps',
                     body=[{'id': str(victim_plan['dep'])}])
     assert resp['statusCode'] == 404
     assert _dep_row(db_connection, victim_plan['dep']) is not None
@@ -368,12 +422,12 @@ def test_bulk_delete_cannot_remove_another_users_edge(intruder, victim_plan,
 
 def test_the_owner_can_still_delete_their_own_edge(invoke, victim_plan, db_connection):
     """Create-and-remove, so the fixture's edge survives for the tests after this."""
-    resp = invoke('POST', '/darwin_dev/pipeline_step_deps',
-                  body={'step_fk': victim_plan['step_a'], 'dep_step_fk': 'NULL',
-                        'time_at': '2026-07-27 03:04:05'})
+    resp = invoke('POST', '/darwin_dev/pipeline2_step_deps',
+                  body={'step_fk': victim_plan['step_a'],
+                        'dep_step_fk': victim_plan['step_c']})
     assert resp['statusCode'] == 200
     throwaway = extract_id(resp)
-    assert invoke('DELETE', '/darwin_dev/pipeline_step_deps',
+    assert invoke('DELETE', '/darwin_dev/pipeline2_step_deps',
                   body={'id': str(throwaway)})['statusCode'] == 200
     assert _dep_row(db_connection, throwaway) is None
 
@@ -386,14 +440,14 @@ def test_post_cannot_add_an_edge_to_a_foreign_step(intruder, victim_plan,
                                                    db_connection):
     """Injecting a gate into somebody else's plan stalls their step indefinitely."""
     before = _count(db_connection,
-                    "SELECT COUNT(*) AS n FROM pipeline_step_deps WHERE step_fk = %s",
+                    "SELECT COUNT(*) AS n FROM pipeline2_step_deps WHERE step_fk = %s",
                     (victim_plan['step_a'],))
-    resp = intruder('POST', '/darwin_dev/pipeline_step_deps',
+    resp = intruder('POST', '/darwin_dev/pipeline2_step_deps',
                     body={'step_fk': str(victim_plan['step_a']),
                           'dep_step_fk': str(victim_plan['step_b'])})
     assert resp['statusCode'] == 403
     assert _count(db_connection,
-                  "SELECT COUNT(*) AS n FROM pipeline_step_deps WHERE step_fk = %s",
+                  "SELECT COUNT(*) AS n FROM pipeline2_step_deps WHERE step_fk = %s",
                   (victim_plan['step_a'],)) == before
 
 
@@ -405,35 +459,35 @@ def test_post_cannot_point_an_owned_edge_at_a_foreign_step(intruder, victim_plan
     step permanently undeletable: a denial of service on their plan, mounted from
     entirely inside the attacker's own pipeline.
     """
-    resp = intruder('POST', '/darwin_dev/pipeline_step_deps',
+    resp = intruder('POST', '/darwin_dev/pipeline2_step_deps',
                     body={'step_fk': str(intruder_plan['step_a']),
                           'dep_step_fk': str(victim_plan['step_b'])})
     assert resp['statusCode'] == 403
     assert _count(db_connection,
-                  "SELECT COUNT(*) AS n FROM pipeline_step_deps WHERE dep_step_fk = %s",
+                  "SELECT COUNT(*) AS n FROM pipeline2_step_deps WHERE dep_step_fk = %s",
                   (victim_plan['step_b'],)) == 0
 
 
 def test_post_cannot_link_a_requirement_to_a_foreign_step(intruder, victim_plan,
                                                           db_connection):
-    resp = intruder('POST', '/darwin_dev/pipeline_step_requirements',
+    resp = intruder('POST', '/darwin_dev/pipeline2_step_requirements',
                     body={'step_fk': str(victim_plan['step_a']),
                           'requirement_fk': str(victim_plan['requirement'])})
     assert resp['statusCode'] == 403
     assert _count(db_connection,
-                  "SELECT COUNT(*) AS n FROM pipeline_step_requirements WHERE step_fk = %s",
+                  "SELECT COUNT(*) AS n FROM pipeline2_step_requirements WHERE step_fk = %s",
                   (victim_plan['step_a'],)) == 1
 
 
 def test_post_cannot_pull_a_foreign_requirement_into_an_owned_step(
         intruder, victim_plan, intruder_plan, db_connection):
     """`requirement_fk` is RESTRICT — this would block the victim's own delete."""
-    resp = intruder('POST', '/darwin_dev/pipeline_step_requirements',
+    resp = intruder('POST', '/darwin_dev/pipeline2_step_requirements',
                     body={'step_fk': str(intruder_plan['step_b']),
                           'requirement_fk': str(victim_plan['requirement'])})
     assert resp['statusCode'] == 403
     assert _count(db_connection,
-                  "SELECT COUNT(*) AS n FROM pipeline_step_requirements "
+                  "SELECT COUNT(*) AS n FROM pipeline2_step_requirements "
                   "WHERE requirement_fk = %s", (victim_plan['requirement'],)) == 1
 
 
@@ -441,30 +495,31 @@ def test_bulk_post_refuses_the_whole_batch_for_one_foreign_row(
         intruder, victim_plan, intruder_plan, db_connection):
     """One multi-value INSERT: a partial accept would be worse than a refusal."""
     before = _count(db_connection,
-                    "SELECT COUNT(*) AS n FROM pipeline_step_deps WHERE step_fk = %s",
+                    "SELECT COUNT(*) AS n FROM pipeline2_step_deps WHERE step_fk = %s",
                     (intruder_plan['step_a'],))
-    resp = intruder('POST', '/darwin_dev/pipeline_step_deps', body=[
-        {'step_fk': str(intruder_plan['step_a']), 'dep_step_fk': None,
-         'time_at': '2026-07-27 04:05:06'},
-        {'step_fk': str(victim_plan['step_a']), 'dep_step_fk': None,
-         'time_at': '2026-07-27 04:05:06'},
+    resp = intruder('POST', '/darwin_dev/pipeline2_step_deps', body=[
+        {'step_fk': str(intruder_plan['step_a']),
+         'dep_step_fk': str(intruder_plan['step_c'])},
+        {'step_fk': str(victim_plan['step_a']),
+         'dep_step_fk': str(intruder_plan['step_c'])},
     ])
     assert resp['statusCode'] == 403
     assert _count(db_connection,
-                  "SELECT COUNT(*) AS n FROM pipeline_step_deps WHERE step_fk = %s",
+                  "SELECT COUNT(*) AS n FROM pipeline2_step_deps WHERE step_fk = %s",
                   (intruder_plan['step_a'],)) == before
 
 
 def test_post_without_the_scope_column_is_400(intruder, victim_plan):
     """Ownership cannot be established — but that is a malformed body, not a
     credentials problem, so it must not read as 403."""
-    resp = intruder('POST', '/darwin_dev/pipeline_step_deps',
+    resp = intruder('POST', '/darwin_dev/pipeline2_step_deps',
                     body={'dep_step_fk': str(victim_plan['step_a'])})
     assert resp['statusCode'] == 400
 
 
 def test_a_nonexistent_step_is_still_the_foreign_key_409_not_a_403(intruder,
-                                                                   victim_plan):
+                                                                   victim_plan,
+                                                                   intruder_plan):
     """Absent and foreign are DIFFERENT answers, deliberately.
 
     403 is reserved for "this row belongs to somebody else". A step id that does
@@ -476,19 +531,21 @@ def test_a_nonexistent_step_is_still_the_foreign_key_409_not_a_403(intruder,
     FK typo a confidently wrong explanation: "references a row another creator
     owns", of a row that does not exist.
     """
-    foreign = intruder('POST', '/darwin_dev/pipeline_step_deps',
-                       body={'step_fk': str(victim_plan['step_a'])})
+    foreign = intruder('POST', '/darwin_dev/pipeline2_step_deps',
+                       body={'step_fk': str(victim_plan['step_a']),
+                             'dep_step_fk': str(intruder_plan['step_c'])})
     assert foreign['statusCode'] == 403
 
-    missing = intruder('POST', '/darwin_dev/pipeline_step_deps',
-                       body={'step_fk': '999999999'})
+    missing = intruder('POST', '/darwin_dev/pipeline2_step_deps',
+                       body={'step_fk': '999999999',
+                             'dep_step_fk': str(intruder_plan['step_c'])})
     assert missing['statusCode'] == 409
     assert json.loads(missing['body'])['errno'] == 1452
 
 
 def test_the_owner_can_still_create_edges_and_links(invoke, victim_plan, db_connection):
     """The whole owner-side write path, after every refusal above."""
-    resp = invoke('POST', '/darwin_dev/pipeline_step_deps',
+    resp = invoke('POST', '/darwin_dev/pipeline2_step_deps',
                   body={'step_fk': victim_plan['step_a'],
                         'dep_step_fk': victim_plan['step_b']})
     assert resp['statusCode'] == 200
@@ -497,7 +554,7 @@ def test_the_owner_can_still_create_edges_and_links(invoke, victim_plan, db_conn
         assert _dep_row(db_connection, new_dep) is not None
     finally:
         with db_connection.cursor() as cur:
-            cur.execute("DELETE FROM pipeline_step_deps WHERE id = %s", (new_dep,))
+            cur.execute("DELETE FROM pipeline2_step_deps WHERE id = %s", (new_dep,))
         db_connection.commit()
 
 
@@ -556,12 +613,12 @@ def test_put_cannot_move_an_owned_edge_onto_a_foreign_step(
     on a dependency they never created — and per the orchestration doctrine an
     unexpected gate means their step is not launched.
     """
-    resp = intruder('PUT', '/darwin_dev/pipeline_step_deps',
+    resp = intruder('PUT', '/darwin_dev/pipeline2_step_deps',
                     body=[{'id': str(intruder_plan['dep']),
                            'step_fk': str(victim_plan['step_a'])}])
     assert resp['statusCode'] == 403
     with db_connection.cursor() as cur:
-        cur.execute("SELECT step_fk FROM pipeline_step_deps WHERE id = %s",
+        cur.execute("SELECT step_fk FROM pipeline2_step_deps WHERE id = %s",
                     (intruder_plan['dep'],))
         assert str(cur.fetchone()['step_fk']) == str(intruder_plan['step_b'])
 
@@ -573,25 +630,26 @@ def test_put_cannot_repoint_an_owned_edge_at_a_foreign_step(
     `dep_step_fk` is ON DELETE RESTRICT: an edge pointing at the victim's step
     makes that step undeletable and unmergeable, from inside the attacker's plan.
     """
-    resp = intruder('PUT', '/darwin_dev/pipeline_step_deps',
+    resp = intruder('PUT', '/darwin_dev/pipeline2_step_deps',
                     body=[{'id': str(intruder_plan['dep']),
                            'dep_step_fk': str(victim_plan['step_b'])}])
     assert resp['statusCode'] == 403
     assert _count(db_connection,
-                  "SELECT COUNT(*) AS n FROM pipeline_step_deps WHERE dep_step_fk = %s",
+                  "SELECT COUNT(*) AS n FROM pipeline2_step_deps WHERE dep_step_fk = %s",
                   (victim_plan['step_b'],)) == 0
 
 
 def test_bulk_put_cannot_smuggle_a_foreign_parent_in_one_row(
         intruder, victim_plan, intruder_plan, db_connection):
     """One CASE statement covers every row, so one bad row refuses the batch."""
-    resp = intruder('PUT', '/darwin_dev/pipeline_step_deps', body=[
-        {'id': str(intruder_plan['dep']), 'time_at': '2026-07-27 05:06:07'},
+    resp = intruder('PUT', '/darwin_dev/pipeline2_step_deps', body=[
+        {'id': str(intruder_plan['dep']),
+         'dep_step_fk': str(intruder_plan['step_c'])},
         {'id': str(intruder_plan['dep']), 'step_fk': str(victim_plan['step_a'])},
     ])
     assert resp['statusCode'] == 403
     with db_connection.cursor() as cur:
-        cur.execute("SELECT step_fk FROM pipeline_step_deps WHERE id = %s",
+        cur.execute("SELECT step_fk FROM pipeline2_step_deps WHERE id = %s",
                     (intruder_plan['dep'],))
         assert str(cur.fetchone()['step_fk']) == str(intruder_plan['step_b'])
 
@@ -599,22 +657,22 @@ def test_bulk_put_cannot_smuggle_a_foreign_parent_in_one_row(
 def test_the_owner_can_still_move_their_own_edge_between_their_own_steps(
         invoke, victim_plan, db_connection):
     """Rewriting the scope column is legitimate — within your own rows."""
-    resp = invoke('POST', '/darwin_dev/pipeline_step_deps',
-                  body={'step_fk': victim_plan['step_a'], 'dep_step_fk': 'NULL',
-                        'time_at': '2026-07-27 07:08:09'})
+    resp = invoke('POST', '/darwin_dev/pipeline2_step_deps',
+                  body={'step_fk': victim_plan['step_a'],
+                        'dep_step_fk': victim_plan['step_c']})
     assert resp['statusCode'] == 200
     moved = extract_id(resp)
     try:
-        assert invoke('PUT', '/darwin_dev/pipeline_step_deps',
+        assert invoke('PUT', '/darwin_dev/pipeline2_step_deps',
                       body=[{'id': str(moved),
                              'step_fk': str(victim_plan['step_b'])}])['statusCode'] == 200
         with db_connection.cursor() as cur:
-            cur.execute("SELECT step_fk FROM pipeline_step_deps WHERE id = %s",
+            cur.execute("SELECT step_fk FROM pipeline2_step_deps WHERE id = %s",
                         (moved,))
             assert str(cur.fetchone()['step_fk']) == str(victim_plan['step_b'])
     finally:
         with db_connection.cursor() as cur:
-            cur.execute("DELETE FROM pipeline_step_deps WHERE id = %s", (moved,))
+            cur.execute("DELETE FROM pipeline2_step_deps WHERE id = %s", (moved,))
         db_connection.commit()
 
 
@@ -666,15 +724,15 @@ def test_delete_body_key_injection_cannot_cancel_the_scoping(
     pre-existing `creator_fk` scoping the same way, on every table.
     """
     before = _count(db_connection,
-                    "SELECT COUNT(*) AS n FROM pipeline_step_deps WHERE step_fk = %s",
+                    "SELECT COUNT(*) AS n FROM pipeline2_step_deps WHERE step_fk = %s",
                     (victim_plan['step_b'],))
     assert before == 1
 
-    resp = intruder('DELETE', '/darwin_dev/pipeline_step_deps', body={
+    resp = intruder('DELETE', '/darwin_dev/pipeline2_step_deps', body={
         f"id = 1 OR step_fk = {victim_plan['step_b']} OR id": '1'})
     assert resp['statusCode'] == 400
     assert _count(db_connection,
-                  "SELECT COUNT(*) AS n FROM pipeline_step_deps WHERE step_fk = %s",
+                  "SELECT COUNT(*) AS n FROM pipeline2_step_deps WHERE step_fk = %s",
                   (victim_plan['step_b'],)) == before
 
 
@@ -689,7 +747,7 @@ def test_delete_body_key_injection_cannot_cancel_creator_fk_scoping(
 
 
 def test_delete_rejects_an_unknown_column_rather_than_interpolating_it(intruder):
-    resp = intruder('DELETE', '/darwin_dev/pipeline_step_deps',
+    resp = intruder('DELETE', '/darwin_dev/pipeline2_step_deps',
                     body={'not_a_column': '1'})
     assert resp['statusCode'] == 400
 
@@ -697,12 +755,12 @@ def test_delete_rejects_an_unknown_column_rather_than_interpolating_it(intruder)
 def test_the_owner_can_still_delete_by_a_real_column(invoke, victim_plan,
                                                      db_connection):
     """Key validation must not break the legitimate multi-key delete."""
-    resp = invoke('POST', '/darwin_dev/pipeline_step_deps',
+    resp = invoke('POST', '/darwin_dev/pipeline2_step_deps',
                   body={'step_fk': victim_plan['step_a'],
                         'dep_step_fk': victim_plan['step_b']})
     assert resp['statusCode'] == 200
     made = extract_id(resp)
-    assert invoke('DELETE', '/darwin_dev/pipeline_step_deps',
+    assert invoke('DELETE', '/darwin_dev/pipeline2_step_deps',
                   body={'step_fk': str(victim_plan['step_a']),
                         'dep_step_fk': str(victim_plan['step_b'])})['statusCode'] == 200
     assert _dep_row(db_connection, made) is None

--- a/tests/test_pipeline2_compose.py
+++ b/tests/test_pipeline2_compose.py
@@ -1,7 +1,7 @@
 """The Pipeline 2.0 composing route — integration tier (req #3367).
 
-`GET /darwin_dev/pipeline2_compose?id=<pipeline_id>` and
-`GET /darwin_dev/pipeline2_compose_epic?id=<epic_id>` — the ONE non-generic
+`GET /darwin_dev/pipeline_compose?id=<pipeline_id>` and
+`GET /darwin_dev/pipeline_compose_epic?id=<epic_id>` — the ONE non-generic
 route this requirement adds. Everything here is driven through
 `lambda_handler` exactly like the generic gateway's own tests, proving the
 route end to end: auth, scoping, shape, derivation, and the budget ladder.
@@ -55,13 +55,13 @@ def _purge(conn, creator):
     import pymysql as _pymysql
     try:
         with conn.cursor() as cur:
-            cur.execute("DELETE FROM pipeline2_step_deps WHERE step_fk IN "
-                        "(SELECT id FROM pipeline2_steps WHERE creator_fk = %s)", (creator,))
-            cur.execute("DELETE FROM pipeline2_step_requirements WHERE step_fk IN "
-                        "(SELECT id FROM pipeline2_steps WHERE creator_fk = %s)", (creator,))
-            cur.execute("DELETE FROM pipeline2_steps WHERE creator_fk = %s", (creator,))
-            cur.execute("DELETE FROM pipeline2_epics WHERE creator_fk = %s", (creator,))
-            cur.execute("DELETE FROM pipeline2_pipelines WHERE creator_fk = %s", (creator,))
+            cur.execute("DELETE FROM pipeline_step_deps WHERE step_fk IN "
+                        "(SELECT id FROM pipeline_steps WHERE creator_fk = %s)", (creator,))
+            cur.execute("DELETE FROM pipeline_step_requirements WHERE step_fk IN "
+                        "(SELECT id FROM pipeline_steps WHERE creator_fk = %s)", (creator,))
+            cur.execute("DELETE FROM pipeline_steps WHERE creator_fk = %s", (creator,))
+            cur.execute("DELETE FROM epics WHERE creator_fk = %s", (creator,))
+            cur.execute("DELETE FROM pipelines WHERE creator_fk = %s", (creator,))
             cur.execute("DELETE FROM requirements WHERE creator_fk = %s", (creator,))
             cur.execute("DELETE FROM categories WHERE creator_fk = %s", (creator,))
             cur.execute("DELETE FROM projects WHERE creator_fk = %s", (creator,))
@@ -104,13 +104,13 @@ def plan(owner):
     assert resp['statusCode'] == 200, resp
     ids['category'] = int(extract_id(resp))
 
-    resp = owner('POST', '/darwin_dev/pipeline2_pipelines', body={
+    resp = owner('POST', '/darwin_dev/pipelines', body={
         'title': 'p2compose plan', 'description': 'the goal',
         'pipeline_status': 'active', 'execution_mode': 'parallel'})
     assert resp['statusCode'] == 200, resp
     ids['pipeline'] = int(extract_id(resp))
 
-    resp = owner('POST', '/darwin_dev/pipeline2_epics', body={
+    resp = owner('POST', '/darwin_dev/epics', body={
         'pipeline_fk': ids['pipeline'], 'title': 'p2compose epic',
         'description': 'build it', 'epic_status': 'active',
         'category_fk': ids['category'], 'sort_order': 'NULL', 'closed': '0'})
@@ -129,20 +129,20 @@ def plan(owner):
     for key, title, run in (('step_a', 'read service', 'auto'),
                             ('step_b', 'tools', 'auto'),
                             ('step_gate', 'gate', 'manual')):
-        resp = owner('POST', '/darwin_dev/pipeline2_steps', body={
+        resp = owner('POST', '/darwin_dev/pipeline_steps', body={
             'epic_fk': ids['epic'], 'title': title, 'run': run})
         assert resp['statusCode'] == 200, resp
         ids[key] = int(extract_id(resp))
 
-    resp = owner('POST', '/darwin_dev/pipeline2_step_requirements',
+    resp = owner('POST', '/darwin_dev/pipeline_step_requirements',
                 body={'step_fk': ids['step_a'], 'requirement_fk': ids['req_a']})
     assert resp['statusCode'] in (200, 201), resp
-    resp = owner('POST', '/darwin_dev/pipeline2_step_requirements',
+    resp = owner('POST', '/darwin_dev/pipeline_step_requirements',
                 body={'step_fk': ids['step_b'], 'requirement_fk': ids['req_b']})
     assert resp['statusCode'] in (200, 201), resp
 
     for dep in (ids['step_a'], ids['step_b']):
-        resp = owner('POST', '/darwin_dev/pipeline2_step_deps',
+        resp = owner('POST', '/darwin_dev/pipeline_step_deps',
                     body={'step_fk': ids['step_gate'], 'dep_step_fk': dep})
         assert resp['statusCode'] == 200, resp
 
@@ -159,7 +159,7 @@ def _get(invoke, table, row_id):
 
 class TestWholePlanCompose:
     def test_carries_the_whole_plan(self, owner, plan):
-        resp = _get(owner, 'pipeline2_compose', plan['pipeline'])
+        resp = _get(owner, 'pipeline_compose', plan['pipeline'])
         assert resp['statusCode'] == 200, resp
         body = json.loads(resp['body'])
 
@@ -185,7 +185,7 @@ class TestWholePlanCompose:
         # (pipelinePlanTime.js) reads them per-requirement and had no
         # evidence at all without this widening. Still light: no
         # `description`, no `feature_fk` (2.0 has no Feature).
-        resp = _get(owner, 'pipeline2_compose', plan['pipeline'])
+        resp = _get(owner, 'pipeline_compose', plan['pipeline'])
         body = json.loads(resp['body'])
         for row in body['requirements']:
             assert set(row) == {'id', 'title', 'requirement_status', 'coordination_type',
@@ -195,7 +195,7 @@ class TestWholePlanCompose:
             assert 'feature_fk' not in row
 
     def test_steps_have_no_state_column_and_epic_fk_not_pipeline_fk(self, owner, plan):
-        resp = _get(owner, 'pipeline2_compose', plan['pipeline'])
+        resp = _get(owner, 'pipeline_compose', plan['pipeline'])
         body = json.loads(resp['body'])
         for step in body['steps']:
             assert 'state' not in step and 'status' not in step
@@ -203,7 +203,7 @@ class TestWholePlanCompose:
             assert step['epic_fk'] == plan['epic']
 
     def test_derived_is_a_real_answer(self, owner, plan):
-        resp = _get(owner, 'pipeline2_compose', plan['pipeline'])
+        resp = _get(owner, 'pipeline_compose', plan['pipeline'])
         body = json.loads(resp['body'])
         derived = body['derived']
         assert 'withheld' not in derived
@@ -216,7 +216,7 @@ class TestWholePlanCompose:
         assert by_id[plan['step_gate']] == 'pending'
 
     def test_missing_pipeline_is_404(self, owner):
-        resp = _get(owner, 'pipeline2_compose', 999999999)
+        resp = _get(owner, 'pipeline_compose', 999999999)
         assert resp['statusCode'] == 404, resp
         assert resp['body'] == '"NOT FOUND"'
 
@@ -231,15 +231,15 @@ class TestWholePlanCompose:
         and the corpus existed to catch it when they did. Proving two calls
         to the one remaining producer return identical bytes is what "one
         derivation, in one place" cashes out to once B is chosen."""
-        first = _get(owner, 'pipeline2_compose', plan['pipeline'])
-        second = _get(owner, 'pipeline2_compose', plan['pipeline'])
+        first = _get(owner, 'pipeline_compose', plan['pipeline'])
+        second = _get(owner, 'pipeline_compose', plan['pipeline'])
         assert first['body'] == second['body']
         assert json.loads(first['body'])['derived'] == json.loads(second['body'])['derived']
 
 
 class TestEpicScopedCompose:
     def test_carries_one_epic(self, owner, plan):
-        resp = _get(owner, 'pipeline2_compose_epic', plan['epic'])
+        resp = _get(owner, 'pipeline_compose_epic', plan['epic'])
         assert resp['statusCode'] == 200, resp
         body = json.loads(resp['body'])
         assert len(body['epics']) == 1
@@ -248,7 +248,7 @@ class TestEpicScopedCompose:
         assert body['pipeline']['id'] == plan['pipeline']
 
     def test_missing_epic_is_404(self, owner):
-        resp = _get(owner, 'pipeline2_compose_epic', 999999999)
+        resp = _get(owner, 'pipeline_compose_epic', 999999999)
         assert resp['statusCode'] == 404, resp
 
 
@@ -260,7 +260,7 @@ class TestScoping:
     def test_unauthenticated_is_403(self, plan):
         from handler import lambda_handler
         resp = lambda_handler({
-            'httpMethod': 'GET', 'path': '/darwin_dev/pipeline2_compose',
+            'httpMethod': 'GET', 'path': '/darwin_dev/pipeline_compose',
             'queryStringParameters': {'id': str(plan['pipeline'])},
             'body': None, 'requestContext': {},
         }, {})
@@ -268,19 +268,19 @@ class TestScoping:
         assert resp['body'] == '"FORBIDDEN"'
 
     def test_another_creator_cannot_read_the_plan(self, other, plan):
-        resp = _get(other, 'pipeline2_compose', plan['pipeline'])
+        resp = _get(other, 'pipeline_compose', plan['pipeline'])
         assert resp['statusCode'] == 404, resp
 
     def test_another_creator_cannot_read_the_epic(self, other, plan):
-        resp = _get(other, 'pipeline2_compose_epic', plan['epic'])
+        resp = _get(other, 'pipeline_compose_epic', plan['epic'])
         assert resp['statusCode'] == 404, resp
 
     def test_missing_id_is_400(self, owner):
-        resp = owner('GET', '/darwin_dev/pipeline2_compose', query=None)
+        resp = owner('GET', '/darwin_dev/pipeline_compose', query=None)
         assert resp['statusCode'] == 400, resp
 
     def test_non_get_is_400(self, owner, plan):
-        resp = owner('POST', '/darwin_dev/pipeline2_compose', body={'id': plan['pipeline']})
+        resp = owner('POST', '/darwin_dev/pipeline_compose', body={'id': plan['pipeline']})
         assert resp['statusCode'] == 400, resp
 
 
@@ -300,23 +300,23 @@ def two_epic_plan(owner):
                 body={'category_name': 'p2compose 2-epic category', 'project_fk': ids['project']})
     ids['category'] = int(extract_id(resp))
 
-    resp = owner('POST', '/darwin_dev/pipeline2_pipelines', body={
+    resp = owner('POST', '/darwin_dev/pipelines', body={
         'title': 'p2compose two epics', 'pipeline_status': 'active',
         'execution_mode': 'parallel'})
     ids['pipeline'] = int(extract_id(resp))
 
     for key, title, order in (('epic_a', 'epic A', '1'), ('epic_b', 'epic B', '2')):
-        resp = owner('POST', '/darwin_dev/pipeline2_epics', body={
+        resp = owner('POST', '/darwin_dev/epics', body={
             'pipeline_fk': ids['pipeline'], 'title': title, 'epic_status': 'active',
             'category_fk': ids['category'], 'sort_order': order, 'closed': '0'})
         assert resp['statusCode'] == 200, resp
         ids[key] = int(extract_id(resp))
 
-    resp = owner('POST', '/darwin_dev/pipeline2_steps',
+    resp = owner('POST', '/darwin_dev/pipeline_steps',
                 body={'epic_fk': ids['epic_a'], 'title': 'A step', 'run': 'auto',
                       'completed_at': '2026-08-01 00:00:00'})
     ids['step_a'] = int(extract_id(resp))
-    resp = owner('POST', '/darwin_dev/pipeline2_steps',
+    resp = owner('POST', '/darwin_dev/pipeline_steps',
                 body={'epic_fk': ids['epic_b'], 'title': 'B step', 'run': 'auto'})
     ids['step_b'] = int(extract_id(resp))
 
@@ -325,15 +325,15 @@ def two_epic_plan(owner):
         'category_fk': ids['category'], 'coordination_type': 'deployed',
         'ai_model': 'sonnet', 'effort': 'high'})
     ids['req'] = int(extract_id(resp))
-    owner('POST', '/darwin_dev/pipeline2_step_requirements',
+    owner('POST', '/darwin_dev/pipeline_step_requirements',
          body={'step_fk': ids['step_b'], 'requirement_fk': ids['req']})
-    owner('POST', '/darwin_dev/pipeline2_step_deps',
+    owner('POST', '/darwin_dev/pipeline_step_deps',
          body={'step_fk': ids['step_b'], 'dep_step_fk': ids['step_a']})
     return ids
 
 
 def test_epic_scoped_reports_out_of_scope_never_dangling(owner, two_epic_plan):
-    resp = _get(owner, 'pipeline2_compose_epic', two_epic_plan['epic_b'])
+    resp = _get(owner, 'pipeline_compose_epic', two_epic_plan['epic_b'])
     body = json.loads(resp['body'])
     derived = body['derived']
     assert derived['out_of_scope_dep_ids'] == [two_epic_plan['step_a']]
@@ -341,7 +341,7 @@ def test_epic_scoped_reports_out_of_scope_never_dangling(owner, two_epic_plan):
 
 
 def test_whole_plan_sees_the_same_edge_as_an_ordinary_satisfied_gate(owner, two_epic_plan):
-    resp = _get(owner, 'pipeline2_compose', two_epic_plan['pipeline'])
+    resp = _get(owner, 'pipeline_compose', two_epic_plan['pipeline'])
     body = json.loads(resp['body'])
     derived = body['derived']
     assert derived['out_of_scope_dep_ids'] == []

--- a/tests/test_pipeline2_gateway_routing.py
+++ b/tests/test_pipeline2_gateway_routing.py
@@ -1,4 +1,5 @@
-"""Pipeline 2.0 API Gateway routing — Lambda-side half (req #3338).
+"""Pipeline plan-layer API Gateway routing — Lambda-side half (req #3338,
+table names updated req #3356).
 
 # COVERS: SCH-023
 
@@ -9,7 +10,10 @@ ways:
 
 - **The Lambda-side half — asserted HERE.** `lambda_handler` correctly parses
   the path, applies `auth_utils` registration, and executes a real SQL query
-  for each of the five `pipeline2_*` tables, proving no application-level
+  for each of the five plan-layer tables (`pipelines`, `epics`,
+  `pipeline_steps`, `pipeline_step_requirements`, `pipeline_step_deps` —
+  named `pipeline2_*` until req #3356 dropped the first generation and
+  renamed these into the freed plain names), proving no application-level
   obstacle (missing registration, an invalid table-name regex match, a
   connection failure) would make a route fail even once the AWS wiring is in
   place. Exercised via `/darwin_dev/*` only, matching this suite's existing
@@ -44,27 +48,35 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 from auth_utils import CREATOR_FK_TABLES, JUNCTION_OWNERSHIP
 
-# Derived, not hand-counted (house style — see test_unit_creator_fk_references.py's
-# own rationale for the same choice): the five pipeline2_* tables are exactly
-# those two registries already name. A sixth pipeline2_* table registered in
-# either registry is picked up here automatically; one registered in neither
-# would still be missed, but that is auth_utils's own registration gap to
-# catch (test_unit_creator_fk_references.py / test_unit_junction_scoping.py),
-# not this file's.
-PIPELINE2_TABLES = sorted(
-    {t for t in CREATOR_FK_TABLES if t.startswith('pipeline2_')}
-    | {t for t in JUNCTION_OWNERSHIP if t.startswith('pipeline2_')}
+# NAMED, not derived by prefix — req #3356 deliberately removed the
+# `pipeline2_` era marker these table names carried, so there is no longer
+# a name pattern that distinguishes the five plan-layer tables from any
+# other creator_fk/junction table in the registries. A prefix-derivation
+# here would either match nothing (as it did for one session between the
+# rename landing and this fix) or, worse, match some unrelated table that
+# happens to share a prefix. The registration gap this file's derivation
+# used to catch for free is still caught — just by
+# test_unit_creator_fk_references.py / test_unit_junction_scoping.py, which
+# check each of these five names individually against schema.sql.
+PIPELINE_PLAN_LAYER_TABLES = (
+    'epics', 'pipelines', 'pipeline_steps',
+    'pipeline_step_requirements', 'pipeline_step_deps',
 )
 
 
-def test_pipeline2_table_count_is_five():
-    """Sanity check on the derivation above, so a registry regression fails
-    loud here rather than silently shrinking the parametrized set below."""
-    assert len(PIPELINE2_TABLES) == 5, PIPELINE2_TABLES
+def test_pipeline_plan_layer_table_count_is_five():
+    """Sanity check on the constant above, so a hand-edit that drops or
+    duplicates an entry fails loud here rather than silently shrinking the
+    parametrized set below."""
+    assert len(PIPELINE_PLAN_LAYER_TABLES) == 5, PIPELINE_PLAN_LAYER_TABLES
+    assert len(set(PIPELINE_PLAN_LAYER_TABLES)) == 5, 'duplicate entry'
+    for _t in PIPELINE_PLAN_LAYER_TABLES:
+        assert _t in CREATOR_FK_TABLES or _t in JUNCTION_OWNERSHIP, (
+            f'{_t} named here but not registered in either auth_utils.py registry')
 
 
 class TestFiveTablesAnswer:
-    """SCH-023 (Lambda-side half): every pipeline2_* table is reachable
+    """SCH-023 (Lambda-side half): every plan-layer table is reachable
     end-to-end through `lambda_handler` — path parsing, `auth_utils`
     registration, and a real SQL query against `darwin_dev`, for all five.
 
@@ -75,7 +87,7 @@ class TestFiveTablesAnswer:
     """
 
     @pytest.mark.integration
-    @pytest.mark.parametrize('table', PIPELINE2_TABLES)
+    @pytest.mark.parametrize('table', PIPELINE_PLAN_LAYER_TABLES)
     def test_get_answers_without_error(self, invoke, table):
         response = invoke('GET', f'/darwin_dev/{table}')
         assert response['statusCode'] in (200, 404), (

--- a/tests/test_unit_creator_fk_references.py
+++ b/tests/test_unit_creator_fk_references.py
@@ -254,8 +254,8 @@ def test_orchestration_claims_pipeline2_columns_are_registered():
     changed shape.
     """
     covered = creator_table_reference_columns('orchestration_claims')
-    assert ('pipeline2_fk', 'pipeline2_pipelines') in covered
-    assert ('epic2_fk', 'pipeline2_epics') in covered
+    assert ('pipeline_fk', 'pipelines') in covered
+    assert ('epic_fk', 'epics') in covered
 
 
 def test_unchecked_creator_references_is_a_written_down_exemption_set():
@@ -363,8 +363,8 @@ def test_the_two_registries_never_name_the_same_table():
 
 def test_referenced_parent_columns_dispatches_to_both_registries():
     assert referenced_parent_columns('test_runs') == [('test_plan_fk', 'test_plans')]
-    assert referenced_parent_columns('pipeline2_step_deps')[0] == ('step_fk',
-                                                                   'pipeline2_steps')
+    assert referenced_parent_columns('pipeline_step_deps')[0] == ('step_fk',
+                                                                   'pipeline_steps')
     assert referenced_parent_columns('profiles') == []
     assert referenced_parent_columns('not_a_table') == []
 

--- a/tests/test_unit_creator_fk_references.py
+++ b/tests/test_unit_creator_fk_references.py
@@ -16,11 +16,13 @@ from the row pinning them: there is no self-service recovery at all.
 **The registry must be COMPLETE, and it is DERIVED here rather than reviewed.**
 That is the load-bearing test in this file. The audit that filed req #3125
 reported "test_runs.test_plan_fk and ten sibling columns"; re-deriving the same
-rule from `schema.sql` gives **47 columns across 29 tables** (36 when #3125
+rule from `schema.sql` gives **40 columns across 26 tables** (36 when #3125
 shipped; req #3186's two `swarm_sessions` attribution FKs and req #3224's three
 `orchestration_claims` ones are the proof the mechanism works — they failed this
-test until registered; req #3355 dropped `features`, taking a column and a
-table back off the count). A hand-counted
+test until registered; req #3355 dropped `features`, and req #3356 dropped the
+whole 1.0 plan layer, taking `epics`, `pipelines` and `pipeline_steps` off the
+table count along with 1.0's two `swarm_sessions` and two `orchestration_claims`
+attribution columns). A hand-counted
 security boundary drifts silently — `test_every_cross_tenant_fk_column_is_registered`
 re-derives it on every run, so a new FK column fails the build instead.
 
@@ -182,9 +184,10 @@ def test_every_cross_tenant_fk_column_is_registered(schema, creator_scoped):
 
     An unregistered column is one POST away from pinning a victim's row forever.
     The previous audit of this exact class hand-counted eleven columns; the DDL
-    says thirty-six — now forty-five, with #3337's four pipeline2_epics/
-    pipeline2_pipelines/pipeline2_steps columns. This is why the list is
-    derived and not reviewed.
+    said thirty-six then, forty-seven at its widest (#3337's four pipeline2_*
+    columns and #3369's two included), and forty since req #3356 dropped the
+    1.0 plan layer. This is why the list is derived and not reviewed: not one of
+    those numbers was ever hand-maintained correctly.
     """
     expected = set(_cross_tenant_fk_columns(schema, creator_scoped))
     missing = sorted(expected - set(_registered()) - set(UNCHECKED_CREATOR_REFERENCES))
@@ -360,8 +363,8 @@ def test_the_two_registries_never_name_the_same_table():
 
 def test_referenced_parent_columns_dispatches_to_both_registries():
     assert referenced_parent_columns('test_runs') == [('test_plan_fk', 'test_plans')]
-    assert referenced_parent_columns('pipeline_step_deps')[0] == ('step_fk',
-                                                                  'pipeline_steps')
+    assert referenced_parent_columns('pipeline2_step_deps')[0] == ('step_fk',
+                                                                   'pipeline2_steps')
     assert referenced_parent_columns('profiles') == []
     assert referenced_parent_columns('not_a_table') == []
 

--- a/tests/test_unit_enum_blank.py
+++ b/tests/test_unit_enum_blank.py
@@ -97,11 +97,11 @@ def _parse_columns(path):
     hand, so "does this registered column exist?" has to be asked against the
     wider set or the hand registration would read as a typo.
 
-    Comments are stripped FIRST. `pipelines.execution_mode` declares its type on
-    one line and `NOT NULL DEFAULT 'parallel'` on the next with a `--` comment
-    between them, so a line-at-a-time parse that respected comments would read
-    the column as nullable and drop the schema's only two real `ENUM(...)`
-    columns without saying so.
+    Comments are stripped FIRST. `pipeline2_pipelines.execution_mode` declares
+    its type on one line and `NOT NULL DEFAULT 'parallel'` on the next with a
+    `--` comment between them, so a line-at-a-time parse that respected comments
+    would read the column as nullable and drop the schema's only real `ENUM(...)`
+    column without saying so.
     """
     candidates, all_text = {}, {}
     table = None
@@ -182,7 +182,7 @@ def test_schema_parse_found_the_columns(candidates, all_text_columns):
     # the two-line real ENUM whose NOT NULL sits under a comment.
     assert 'ai_model' in candidates['requirements']
     assert 'effort' in candidates['requirements']
-    assert 'execution_mode' in candidates['pipelines']
+    assert 'execution_mode' in candidates['pipeline2_pipelines']
     # The wider set is a superset and reaches past NARROW.
     assert _pairs(candidates) <= _pairs(all_text_columns)
     assert 'skill_name' in all_text_columns['swarm_completes']

--- a/tests/test_unit_enum_blank.py
+++ b/tests/test_unit_enum_blank.py
@@ -182,7 +182,7 @@ def test_schema_parse_found_the_columns(candidates, all_text_columns):
     # the two-line real ENUM whose NOT NULL sits under a comment.
     assert 'ai_model' in candidates['requirements']
     assert 'effort' in candidates['requirements']
-    assert 'execution_mode' in candidates['pipeline2_pipelines']
+    assert 'execution_mode' in candidates['pipelines']
     # The wider set is a superset and reaches past NARROW.
     assert _pairs(candidates) <= _pairs(all_text_columns)
     assert 'skill_name' in all_text_columns['swarm_completes']

--- a/tests/test_unit_junction_scoping.py
+++ b/tests/test_unit_junction_scoping.py
@@ -88,7 +88,7 @@ def schema():
 def test_schema_parse_found_the_tables(schema):
     """Guard the guard: an empty parse would make every test below vacuous."""
     assert len(schema) > 40, f'parsed only {len(schema)} tables from schema.sql'
-    assert schema['pipeline2_step_deps']['columns'] >= {'id', 'step_fk', 'dep_step_fk'}
+    assert schema['pipeline_step_deps']['columns'] >= {'id', 'step_fk', 'dep_step_fk'}
     assert schema['requirements']['has_creator_fk']
 
 
@@ -99,8 +99,8 @@ def test_every_unscoped_table_is_registered(schema):
     THE invariant of req #3122. `profiles` is scoped by `id` and is the one
     permitted special case; `UNSCOPED_TABLES` is the written-down escape hatch and
     is empty. Anything else absent from both is unscoped on GET/PUT/DELETE/POST.
-    Derived from schema.sql, so it fails helpfully if pipeline2_step_deps or
-    pipeline2_step_requirements (neither carries creator_fk) is missing from
+    Derived from schema.sql, so it fails helpfully if pipeline_step_deps or
+    pipeline_step_requirements (neither carries creator_fk) is missing from
     JUNCTION_OWNERSHIP.
     """
     unscoped = {name for name, info in schema.items()
@@ -136,8 +136,8 @@ def test_every_registered_table_exists_in_the_schema(schema):
 def test_every_parent_is_itself_creator_scoped():
     """Deriving through an unscoped parent would prove nothing.
 
-    `step_fk IN (SELECT id FROM pipeline2_steps WHERE creator_fk = %s)` is only an
-    authorization check because `pipeline2_steps` HAS a creator_fk. Point a rule at
+    `step_fk IN (SELECT id FROM pipeline_steps WHERE creator_fk = %s)` is only an
+    authorization check because `pipeline_steps` HAS a creator_fk. Point a rule at
     a table that does not and the subquery silently authorizes everybody.
     """
     for table in JUNCTION_OWNERSHIP:
@@ -212,8 +212,8 @@ def test_scope_clause_is_none_for_unregistered_tables():
 
 
 def test_scope_clause_shape():
-    assert (junction_scope_clause('pipeline2_step_deps')
-            == 'step_fk IN (SELECT id FROM pipeline2_steps WHERE creator_fk = %s)')
+    assert (junction_scope_clause('pipeline_step_deps')
+            == 'step_fk IN (SELECT id FROM pipeline_steps WHERE creator_fk = %s)')
 
 
 # ---------------------------------------------------------------------------
@@ -297,21 +297,21 @@ class FakeCursor:
 
 # Steps 1 and 2 and requirement 10 are the victim's; 3 and 11 belong to somebody
 # else; anything else does not exist.
-ROWS = {'pipeline2_steps': {1: 'victim', 2: 'victim', 3: 'stranger'},
+ROWS = {'pipeline_steps': {1: 'victim', 2: 'victim', 3: 'stranger'},
         'requirements': {10: 'victim', 11: 'stranger'}}
 
 
 def test_allows_a_write_whose_parents_are_all_owned():
     cursor = FakeCursor(ROWS)
     assert check_junction_parent_ownership(
-        cursor, 'pipeline2_step_deps',
+        cursor, 'pipeline_step_deps',
         [{'step_fk': 1, 'dep_step_fk': 2}], 'victim') is None
 
 
 def test_refuses_a_foreign_scope_parent():
     cursor = FakeCursor(ROWS)
     assert check_junction_parent_ownership(
-        cursor, 'pipeline2_step_deps', [{'step_fk': 3}], 'victim') == (403, 'FORBIDDEN')
+        cursor, 'pipeline_step_deps', [{'step_fk': 3}], 'victim') == (403, 'FORBIDDEN')
 
 
 def test_refuses_a_foreign_verify_parent_on_an_owned_row():
@@ -323,7 +323,7 @@ def test_refuses_a_foreign_verify_parent_on_an_owned_row():
     """
     cursor = FakeCursor(ROWS)
     assert check_junction_parent_ownership(
-        cursor, 'pipeline2_step_deps',
+        cursor, 'pipeline_step_deps',
         [{'step_fk': 1, 'dep_step_fk': 3}], 'victim') == (403, 'FORBIDDEN')
 
 
@@ -340,17 +340,17 @@ def test_a_nonexistent_parent_is_left_to_the_foreign_key_not_refused_here():
     """
     cursor = FakeCursor(ROWS)
     assert check_junction_parent_ownership(
-        cursor, 'pipeline2_step_deps',
+        cursor, 'pipeline_step_deps',
         [{'step_fk': 1, 'dep_step_fk': 999999}], 'victim') is None
     assert check_junction_parent_ownership(
-        cursor, 'pipeline2_step_deps', [{'step_fk': 999999}], 'victim') is None
+        cursor, 'pipeline_step_deps', [{'step_fk': 999999}], 'victim') is None
 
 
 def test_one_foreign_id_refuses_even_when_the_others_are_absent():
     """A missing id must not launder a foreign one sharing the same query."""
     cursor = FakeCursor(ROWS)
     assert check_junction_parent_ownership(
-        cursor, 'pipeline2_step_requirements',
+        cursor, 'pipeline_step_requirements',
         [{'step_fk': 1, 'requirement_fk': 999999},
          {'step_fk': 1, 'requirement_fk': 11}], 'victim') == (403, 'FORBIDDEN')
 
@@ -363,12 +363,12 @@ def test_null_verify_columns_are_skipped_not_refused():
     Turning an absent reference into a 403 would blame the caller's identity for
     a value that names nobody. (Until req #3356 the live example was 1.0's
     wall-clock gate row, which legitimately carried `dep_step_fk: None`;
-    `pipeline2_step_deps.dep_step_fk` is NOT NULL, and the guard's behaviour on a
+    `pipeline_step_deps.dep_step_fk` is NOT NULL, and the guard's behaviour on a
     NULL is unchanged and still the one under test.)
     """
     cursor = FakeCursor(ROWS)
     assert check_junction_parent_ownership(
-        cursor, 'pipeline2_step_deps',
+        cursor, 'pipeline_step_deps',
         [{'step_fk': 1, 'dep_step_fk': None}],
         'victim') is None
 
@@ -382,14 +382,14 @@ def test_a_missing_scope_column_is_400_not_403():
     """
     cursor = FakeCursor(ROWS)
     assert check_junction_parent_ownership(
-        cursor, 'pipeline2_step_deps', [{'dep_step_fk': 1}], 'victim') == (400, 'BAD REQUEST')
+        cursor, 'pipeline_step_deps', [{'dep_step_fk': 1}], 'victim') == (400, 'BAD REQUEST')
 
 
 def test_a_null_scope_column_is_400():
     cursor = FakeCursor(ROWS)
     for empty in (None, 'NULL'):
         assert check_junction_parent_ownership(
-            cursor, 'pipeline2_step_deps', [{'step_fk': empty}], 'victim') \
+            cursor, 'pipeline_step_deps', [{'step_fk': empty}], 'victim') \
             == (400, 'BAD REQUEST')
 
 
@@ -402,7 +402,7 @@ def test_an_empty_string_scope_column_is_CHECKED_as_row_zero_not_treated_as_null
     a value the statement writes completely unchecked — the same
     check-says-one-thing-writer-does-another shape as the `'9825_0'` bug.
 
-    Answer moves from 400 to whatever row 0 turns out to be. Here `pipeline2_steps`
+    Answer moves from 400 to whatever row 0 turns out to be. Here `pipeline_steps`
     has no row 0, so it falls through to the FK as a 409/1452 — still a refusal,
     now for the true reason. On `priority_card_order`, which declares NO foreign
     key, this is the difference between refusing and writing a permanently
@@ -410,7 +410,7 @@ def test_an_empty_string_scope_column_is_CHECKED_as_row_zero_not_treated_as_null
     """
     cursor = FakeCursor(ROWS)
     assert check_junction_parent_ownership(
-        cursor, 'pipeline2_step_deps', [{'step_fk': ''}], 'victim') is None
+        cursor, 'pipeline_step_deps', [{'step_fk': ''}], 'victim') is None
     assert cursor.queries[0][1] == ('0',), 'row 0 was not the id looked up'
 
 
@@ -445,7 +445,7 @@ def test_a_single_foreign_row_refuses_the_whole_batch():
     bodies = [{'step_fk': 1, 'requirement_fk': 10},
               {'step_fk': 3, 'requirement_fk': 10}]
     assert check_junction_parent_ownership(
-        cursor, 'pipeline2_step_requirements', bodies, 'victim') == (403, 'FORBIDDEN')
+        cursor, 'pipeline_step_requirements', bodies, 'victim') == (403, 'FORBIDDEN')
 
 
 def test_mixed_int_and_str_ids_collapse_to_one():
@@ -454,7 +454,7 @@ def test_mixed_int_and_str_ids_collapse_to_one():
     bodies = [{'step_fk': 1, 'requirement_fk': 10},
               {'step_fk': '1', 'requirement_fk': '10'}]
     assert check_junction_parent_ownership(
-        cursor, 'pipeline2_step_requirements', bodies, 'victim') is None
+        cursor, 'pipeline_step_requirements', bodies, 'victim') is None
     for _, params in cursor.queries:
         assert len(params) == 1
 
@@ -475,14 +475,14 @@ def test_no_authenticated_user_skips_the_check():
     """
     cursor = FakeCursor(ROWS)
     assert check_junction_parent_ownership(
-        cursor, 'pipeline2_step_deps', [{'step_fk': 1}], None) is None
+        cursor, 'pipeline_step_deps', [{'step_fk': 1}], None) is None
     assert cursor.queries == []
 
 
 def test_a_non_dict_body_is_rejected_rather_than_crashing():
     cursor = FakeCursor(ROWS)
     assert check_junction_parent_ownership(
-        cursor, 'pipeline2_step_deps', ['not-a-dict'], 'victim') == (400, 'BAD REQUEST')
+        cursor, 'pipeline_step_deps', ['not-a-dict'], 'victim') == (400, 'BAD REQUEST')
 
 
 def test_the_write_guard_opens_no_cursor_when_it_does_not_apply():
@@ -516,7 +516,7 @@ def test_the_write_guard_opens_no_cursor_when_it_does_not_apply():
         require_scope=False) is None
     # No identity — nothing to derive an answer from.
     assert parent_reference_guard(
-        ExplodingConn(), 'pipeline2_step_deps', [{'step_fk': 1}], None, 'POST') is None
+        ExplodingConn(), 'pipeline_step_deps', [{'step_fk': 1}], None, 'POST') is None
     # In neither registry.
     assert parent_reference_guard(
         ExplodingConn(), 'profiles', [{'name': 'x'}], 'victim', 'PUT') is None
@@ -548,7 +548,7 @@ def test_put_omitting_the_scope_column_is_not_a_400():
     """
     cursor = FakeCursor(ROWS)
     assert check_junction_parent_ownership(
-        cursor, 'pipeline2_step_deps', [{'id': 7}],
+        cursor, 'pipeline_step_deps', [{'id': 7}],
         'victim', require_scope=False) is None
 
 
@@ -558,7 +558,7 @@ def test_put_still_refuses_a_foreign_scope_column_when_it_IS_present():
     parent BEFORE the statement."""
     cursor = FakeCursor(ROWS)
     assert check_junction_parent_ownership(
-        cursor, 'pipeline2_step_deps', [{'step_fk': 3}], 'victim',
+        cursor, 'pipeline_step_deps', [{'step_fk': 3}], 'victim',
         require_scope=False) == (403, 'FORBIDDEN')
 
 
@@ -632,26 +632,26 @@ TRUNCATING_VARIANTS = ['9825.000', '9825abc', '9825 rows',
 
 @pytest.mark.parametrize('variant', COERCION_VARIANTS)
 def test_a_foreign_parent_is_refused_in_every_numeric_form(variant):
-    cursor = FakeCursor({'pipeline2_steps': {9825: 'stranger'}})
+    cursor = FakeCursor({'pipeline_steps': {9825: 'stranger'}})
     assert check_junction_parent_ownership(
-        cursor, 'pipeline2_step_deps', [{'step_fk': variant}],
+        cursor, 'pipeline_step_deps', [{'step_fk': variant}],
         'victim') == (403, 'FORBIDDEN')
 
 
 @pytest.mark.parametrize('variant', COERCION_VARIANTS)
 def test_a_foreign_verify_target_is_refused_in_every_numeric_form(variant):
-    cursor = FakeCursor({'pipeline2_steps': {1: 'victim', 9825: 'stranger'}})
+    cursor = FakeCursor({'pipeline_steps': {1: 'victim', 9825: 'stranger'}})
     assert check_junction_parent_ownership(
-        cursor, 'pipeline2_step_deps', [{'step_fk': 1, 'dep_step_fk': variant}],
+        cursor, 'pipeline_step_deps', [{'step_fk': 1, 'dep_step_fk': variant}],
         'victim') == (403, 'FORBIDDEN')
 
 
 @pytest.mark.parametrize('variant', COERCION_VARIANTS)
 def test_the_same_forms_are_refused_on_a_put(variant):
     """The PUT guard shares the check, so it shares the bypass if one exists."""
-    cursor = FakeCursor({'pipeline2_steps': {9825: 'stranger'}})
+    cursor = FakeCursor({'pipeline_steps': {9825: 'stranger'}})
     assert check_junction_parent_ownership(
-        cursor, 'pipeline2_step_deps', [{'step_fk': variant}], 'victim',
+        cursor, 'pipeline_step_deps', [{'step_fk': variant}], 'victim',
         require_scope=False) == (403, 'FORBIDDEN')
 
 
@@ -662,9 +662,9 @@ def test_an_OWNED_parent_is_still_allowed_in_every_numeric_form(variant):
     The same keying bug ran backwards on `fk_enforced: False` — an owned domain
     sent as a float was logged as "does not exist" and refused.
     """
-    cursor = FakeCursor({'pipeline2_steps': {9825: 'victim'}})
+    cursor = FakeCursor({'pipeline_steps': {9825: 'victim'}})
     assert check_junction_parent_ownership(
-        cursor, 'pipeline2_step_deps', [{'step_fk': variant}], 'victim') is None
+        cursor, 'pipeline_step_deps', [{'step_fk': variant}], 'victim') is None
 
 
 @pytest.mark.parametrize('variant', COERCION_VARIANTS)
@@ -677,9 +677,9 @@ def test_priority_card_order_accepts_an_owned_domain_in_every_numeric_form(varia
 
 def test_a_non_integer_parent_reference_is_400_not_a_silent_truncation():
     """`'9825abc'` truncates to 9825 under this instance's non-strict sql_mode."""
-    cursor = FakeCursor({'pipeline2_steps': {9825: 'stranger'}})
+    cursor = FakeCursor({'pipeline_steps': {9825: 'stranger'}})
     assert check_junction_parent_ownership(
-        cursor, 'pipeline2_step_deps', [{'step_fk': '9825abc'}],
+        cursor, 'pipeline_step_deps', [{'step_fk': '9825abc'}],
         'victim') == (400, 'BAD REQUEST')
     assert cursor.queries == []
 
@@ -714,9 +714,9 @@ def test_forms_only_mysql_would_read_as_an_id_are_refused_before_any_lookup(vari
     `'9825abc'` truncates to 9825 silently. Refusing at the door means the
     ownership check never has to reason about a value two layers disagree on.
     """
-    cursor = FakeCursor({'pipeline2_steps': {9825: 'stranger'}})
+    cursor = FakeCursor({'pipeline_steps': {9825: 'stranger'}})
     assert check_junction_parent_ownership(
-        cursor, 'pipeline2_step_deps', [{'step_fk': variant}],
+        cursor, 'pipeline_step_deps', [{'step_fk': variant}],
         'victim') == (400, 'BAD REQUEST')
     assert cursor.queries == []
 

--- a/tests/test_unit_junction_scoping.py
+++ b/tests/test_unit_junction_scoping.py
@@ -88,7 +88,7 @@ def schema():
 def test_schema_parse_found_the_tables(schema):
     """Guard the guard: an empty parse would make every test below vacuous."""
     assert len(schema) > 40, f'parsed only {len(schema)} tables from schema.sql'
-    assert schema['pipeline_step_deps']['columns'] >= {'id', 'step_fk', 'dep_step_fk'}
+    assert schema['pipeline2_step_deps']['columns'] >= {'id', 'step_fk', 'dep_step_fk'}
     assert schema['requirements']['has_creator_fk']
 
 
@@ -136,8 +136,8 @@ def test_every_registered_table_exists_in_the_schema(schema):
 def test_every_parent_is_itself_creator_scoped():
     """Deriving through an unscoped parent would prove nothing.
 
-    `step_fk IN (SELECT id FROM pipeline_steps WHERE creator_fk = %s)` is only an
-    authorization check because `pipeline_steps` HAS a creator_fk. Point a rule at
+    `step_fk IN (SELECT id FROM pipeline2_steps WHERE creator_fk = %s)` is only an
+    authorization check because `pipeline2_steps` HAS a creator_fk. Point a rule at
     a table that does not and the subquery silently authorizes everybody.
     """
     for table in JUNCTION_OWNERSHIP:
@@ -212,8 +212,8 @@ def test_scope_clause_is_none_for_unregistered_tables():
 
 
 def test_scope_clause_shape():
-    assert (junction_scope_clause('pipeline_step_deps')
-            == 'step_fk IN (SELECT id FROM pipeline_steps WHERE creator_fk = %s)')
+    assert (junction_scope_clause('pipeline2_step_deps')
+            == 'step_fk IN (SELECT id FROM pipeline2_steps WHERE creator_fk = %s)')
 
 
 # ---------------------------------------------------------------------------
@@ -297,21 +297,21 @@ class FakeCursor:
 
 # Steps 1 and 2 and requirement 10 are the victim's; 3 and 11 belong to somebody
 # else; anything else does not exist.
-ROWS = {'pipeline_steps': {1: 'victim', 2: 'victim', 3: 'stranger'},
+ROWS = {'pipeline2_steps': {1: 'victim', 2: 'victim', 3: 'stranger'},
         'requirements': {10: 'victim', 11: 'stranger'}}
 
 
 def test_allows_a_write_whose_parents_are_all_owned():
     cursor = FakeCursor(ROWS)
     assert check_junction_parent_ownership(
-        cursor, 'pipeline_step_deps',
-        [{'step_fk': 1, 'dep_step_fk': 2, 'time_at': None}], 'victim') is None
+        cursor, 'pipeline2_step_deps',
+        [{'step_fk': 1, 'dep_step_fk': 2}], 'victim') is None
 
 
 def test_refuses_a_foreign_scope_parent():
     cursor = FakeCursor(ROWS)
     assert check_junction_parent_ownership(
-        cursor, 'pipeline_step_deps', [{'step_fk': 3}], 'victim') == (403, 'FORBIDDEN')
+        cursor, 'pipeline2_step_deps', [{'step_fk': 3}], 'victim') == (403, 'FORBIDDEN')
 
 
 def test_refuses_a_foreign_verify_parent_on_an_owned_row():
@@ -323,7 +323,7 @@ def test_refuses_a_foreign_verify_parent_on_an_owned_row():
     """
     cursor = FakeCursor(ROWS)
     assert check_junction_parent_ownership(
-        cursor, 'pipeline_step_deps',
+        cursor, 'pipeline2_step_deps',
         [{'step_fk': 1, 'dep_step_fk': 3}], 'victim') == (403, 'FORBIDDEN')
 
 
@@ -340,27 +340,36 @@ def test_a_nonexistent_parent_is_left_to_the_foreign_key_not_refused_here():
     """
     cursor = FakeCursor(ROWS)
     assert check_junction_parent_ownership(
-        cursor, 'pipeline_step_deps',
+        cursor, 'pipeline2_step_deps',
         [{'step_fk': 1, 'dep_step_fk': 999999}], 'victim') is None
     assert check_junction_parent_ownership(
-        cursor, 'pipeline_step_deps', [{'step_fk': 999999}], 'victim') is None
+        cursor, 'pipeline2_step_deps', [{'step_fk': 999999}], 'victim') is None
 
 
 def test_one_foreign_id_refuses_even_when_the_others_are_absent():
     """A missing id must not launder a foreign one sharing the same query."""
     cursor = FakeCursor(ROWS)
     assert check_junction_parent_ownership(
-        cursor, 'pipeline_step_requirements',
+        cursor, 'pipeline2_step_requirements',
         [{'step_fk': 1, 'requirement_fk': 999999},
          {'step_fk': 1, 'requirement_fk': 11}], 'victim') == (403, 'FORBIDDEN')
 
 
 def test_null_verify_columns_are_skipped_not_refused():
-    """A wall-clock gate row carries `dep_step_fk: None` and is perfectly legal."""
+    """A NULL verify column names no row, so there is nothing to own.
+
+    The guard's answer must be "not my refusal to make" — whether the column is
+    nullable is the DATABASE's question, and a NOT NULL one answers it with 1048.
+    Turning an absent reference into a 403 would blame the caller's identity for
+    a value that names nobody. (Until req #3356 the live example was 1.0's
+    wall-clock gate row, which legitimately carried `dep_step_fk: None`;
+    `pipeline2_step_deps.dep_step_fk` is NOT NULL, and the guard's behaviour on a
+    NULL is unchanged and still the one under test.)
+    """
     cursor = FakeCursor(ROWS)
     assert check_junction_parent_ownership(
-        cursor, 'pipeline_step_deps',
-        [{'step_fk': 1, 'dep_step_fk': None, 'time_at': '2026-07-27 06:31:38'}],
+        cursor, 'pipeline2_step_deps',
+        [{'step_fk': 1, 'dep_step_fk': None}],
         'victim') is None
 
 
@@ -373,14 +382,14 @@ def test_a_missing_scope_column_is_400_not_403():
     """
     cursor = FakeCursor(ROWS)
     assert check_junction_parent_ownership(
-        cursor, 'pipeline_step_deps', [{'dep_step_fk': 1}], 'victim') == (400, 'BAD REQUEST')
+        cursor, 'pipeline2_step_deps', [{'dep_step_fk': 1}], 'victim') == (400, 'BAD REQUEST')
 
 
 def test_a_null_scope_column_is_400():
     cursor = FakeCursor(ROWS)
     for empty in (None, 'NULL'):
         assert check_junction_parent_ownership(
-            cursor, 'pipeline_step_deps', [{'step_fk': empty}], 'victim') \
+            cursor, 'pipeline2_step_deps', [{'step_fk': empty}], 'victim') \
             == (400, 'BAD REQUEST')
 
 
@@ -393,7 +402,7 @@ def test_an_empty_string_scope_column_is_CHECKED_as_row_zero_not_treated_as_null
     a value the statement writes completely unchecked — the same
     check-says-one-thing-writer-does-another shape as the `'9825_0'` bug.
 
-    Answer moves from 400 to whatever row 0 turns out to be. Here `pipeline_steps`
+    Answer moves from 400 to whatever row 0 turns out to be. Here `pipeline2_steps`
     has no row 0, so it falls through to the FK as a 409/1452 — still a refusal,
     now for the true reason. On `priority_card_order`, which declares NO foreign
     key, this is the difference between refusing and writing a permanently
@@ -401,7 +410,7 @@ def test_an_empty_string_scope_column_is_CHECKED_as_row_zero_not_treated_as_null
     """
     cursor = FakeCursor(ROWS)
     assert check_junction_parent_ownership(
-        cursor, 'pipeline_step_deps', [{'step_fk': ''}], 'victim') is None
+        cursor, 'pipeline2_step_deps', [{'step_fk': ''}], 'victim') is None
     assert cursor.queries[0][1] == ('0',), 'row 0 was not the id looked up'
 
 
@@ -436,7 +445,7 @@ def test_a_single_foreign_row_refuses_the_whole_batch():
     bodies = [{'step_fk': 1, 'requirement_fk': 10},
               {'step_fk': 3, 'requirement_fk': 10}]
     assert check_junction_parent_ownership(
-        cursor, 'pipeline_step_requirements', bodies, 'victim') == (403, 'FORBIDDEN')
+        cursor, 'pipeline2_step_requirements', bodies, 'victim') == (403, 'FORBIDDEN')
 
 
 def test_mixed_int_and_str_ids_collapse_to_one():
@@ -445,7 +454,7 @@ def test_mixed_int_and_str_ids_collapse_to_one():
     bodies = [{'step_fk': 1, 'requirement_fk': 10},
               {'step_fk': '1', 'requirement_fk': '10'}]
     assert check_junction_parent_ownership(
-        cursor, 'pipeline_step_requirements', bodies, 'victim') is None
+        cursor, 'pipeline2_step_requirements', bodies, 'victim') is None
     for _, params in cursor.queries:
         assert len(params) == 1
 
@@ -466,14 +475,14 @@ def test_no_authenticated_user_skips_the_check():
     """
     cursor = FakeCursor(ROWS)
     assert check_junction_parent_ownership(
-        cursor, 'pipeline_step_deps', [{'step_fk': 1}], None) is None
+        cursor, 'pipeline2_step_deps', [{'step_fk': 1}], None) is None
     assert cursor.queries == []
 
 
 def test_a_non_dict_body_is_rejected_rather_than_crashing():
     cursor = FakeCursor(ROWS)
     assert check_junction_parent_ownership(
-        cursor, 'pipeline_step_deps', ['not-a-dict'], 'victim') == (400, 'BAD REQUEST')
+        cursor, 'pipeline2_step_deps', ['not-a-dict'], 'victim') == (400, 'BAD REQUEST')
 
 
 def test_the_write_guard_opens_no_cursor_when_it_does_not_apply():
@@ -507,7 +516,7 @@ def test_the_write_guard_opens_no_cursor_when_it_does_not_apply():
         require_scope=False) is None
     # No identity — nothing to derive an answer from.
     assert parent_reference_guard(
-        ExplodingConn(), 'pipeline_step_deps', [{'step_fk': 1}], None, 'POST') is None
+        ExplodingConn(), 'pipeline2_step_deps', [{'step_fk': 1}], None, 'POST') is None
     # In neither registry.
     assert parent_reference_guard(
         ExplodingConn(), 'profiles', [{'name': 'x'}], 'victim', 'PUT') is None
@@ -539,7 +548,7 @@ def test_put_omitting_the_scope_column_is_not_a_400():
     """
     cursor = FakeCursor(ROWS)
     assert check_junction_parent_ownership(
-        cursor, 'pipeline_step_deps', [{'time_at': '2026-07-27 00:00:00'}],
+        cursor, 'pipeline2_step_deps', [{'id': 7}],
         'victim', require_scope=False) is None
 
 
@@ -549,7 +558,7 @@ def test_put_still_refuses_a_foreign_scope_column_when_it_IS_present():
     parent BEFORE the statement."""
     cursor = FakeCursor(ROWS)
     assert check_junction_parent_ownership(
-        cursor, 'pipeline_step_deps', [{'step_fk': 3}], 'victim',
+        cursor, 'pipeline2_step_deps', [{'step_fk': 3}], 'victim',
         require_scope=False) == (403, 'FORBIDDEN')
 
 
@@ -623,26 +632,26 @@ TRUNCATING_VARIANTS = ['9825.000', '9825abc', '9825 rows',
 
 @pytest.mark.parametrize('variant', COERCION_VARIANTS)
 def test_a_foreign_parent_is_refused_in_every_numeric_form(variant):
-    cursor = FakeCursor({'pipeline_steps': {9825: 'stranger'}})
+    cursor = FakeCursor({'pipeline2_steps': {9825: 'stranger'}})
     assert check_junction_parent_ownership(
-        cursor, 'pipeline_step_deps', [{'step_fk': variant}],
+        cursor, 'pipeline2_step_deps', [{'step_fk': variant}],
         'victim') == (403, 'FORBIDDEN')
 
 
 @pytest.mark.parametrize('variant', COERCION_VARIANTS)
 def test_a_foreign_verify_target_is_refused_in_every_numeric_form(variant):
-    cursor = FakeCursor({'pipeline_steps': {1: 'victim', 9825: 'stranger'}})
+    cursor = FakeCursor({'pipeline2_steps': {1: 'victim', 9825: 'stranger'}})
     assert check_junction_parent_ownership(
-        cursor, 'pipeline_step_deps', [{'step_fk': 1, 'dep_step_fk': variant}],
+        cursor, 'pipeline2_step_deps', [{'step_fk': 1, 'dep_step_fk': variant}],
         'victim') == (403, 'FORBIDDEN')
 
 
 @pytest.mark.parametrize('variant', COERCION_VARIANTS)
 def test_the_same_forms_are_refused_on_a_put(variant):
     """The PUT guard shares the check, so it shares the bypass if one exists."""
-    cursor = FakeCursor({'pipeline_steps': {9825: 'stranger'}})
+    cursor = FakeCursor({'pipeline2_steps': {9825: 'stranger'}})
     assert check_junction_parent_ownership(
-        cursor, 'pipeline_step_deps', [{'step_fk': variant}], 'victim',
+        cursor, 'pipeline2_step_deps', [{'step_fk': variant}], 'victim',
         require_scope=False) == (403, 'FORBIDDEN')
 
 
@@ -653,9 +662,9 @@ def test_an_OWNED_parent_is_still_allowed_in_every_numeric_form(variant):
     The same keying bug ran backwards on `fk_enforced: False` — an owned domain
     sent as a float was logged as "does not exist" and refused.
     """
-    cursor = FakeCursor({'pipeline_steps': {9825: 'victim'}})
+    cursor = FakeCursor({'pipeline2_steps': {9825: 'victim'}})
     assert check_junction_parent_ownership(
-        cursor, 'pipeline_step_deps', [{'step_fk': variant}], 'victim') is None
+        cursor, 'pipeline2_step_deps', [{'step_fk': variant}], 'victim') is None
 
 
 @pytest.mark.parametrize('variant', COERCION_VARIANTS)
@@ -668,9 +677,9 @@ def test_priority_card_order_accepts_an_owned_domain_in_every_numeric_form(varia
 
 def test_a_non_integer_parent_reference_is_400_not_a_silent_truncation():
     """`'9825abc'` truncates to 9825 under this instance's non-strict sql_mode."""
-    cursor = FakeCursor({'pipeline_steps': {9825: 'stranger'}})
+    cursor = FakeCursor({'pipeline2_steps': {9825: 'stranger'}})
     assert check_junction_parent_ownership(
-        cursor, 'pipeline_step_deps', [{'step_fk': '9825abc'}],
+        cursor, 'pipeline2_step_deps', [{'step_fk': '9825abc'}],
         'victim') == (400, 'BAD REQUEST')
     assert cursor.queries == []
 
@@ -705,9 +714,9 @@ def test_forms_only_mysql_would_read_as_an_id_are_refused_before_any_lookup(vari
     `'9825abc'` truncates to 9825 silently. Refusing at the door means the
     ownership check never has to reason about a value two layers disagree on.
     """
-    cursor = FakeCursor({'pipeline_steps': {9825: 'stranger'}})
+    cursor = FakeCursor({'pipeline2_steps': {9825: 'stranger'}})
     assert check_junction_parent_ownership(
-        cursor, 'pipeline_step_deps', [{'step_fk': variant}],
+        cursor, 'pipeline2_step_deps', [{'step_fk': variant}],
         'victim') == (400, 'BAD REQUEST')
     assert cursor.queries == []
 


### PR DESCRIPTION
## Summary
- Fix test files never updated for the pipeline2->plain rename (req #3356)
- Rename pipeline2_compose/pipeline2_compose_epic routes to plain (req #3356)
- Fix auth_utils.py registries' hardcoded pipeline2_* names after the rename
- Fix hardcoded pipeline2_* table names after the schema rename (req #3356)
- wip(3356): drop 1.0 entries from auth_utils.py's four schema-derived registries
- chore: init swarm session feature/3356-pipeline-20-eradicate-the-first-1

## Files changed
```
 CLAUDE.md                                      |  20 ++-
 auth_utils.py                                  | 118 ++++++--------
 handler.py                                     |  18 +--
 pipeline2_compose.py                           |  28 ++--
 tests/test_creator_fk_references_exhaustive.py |  53 +++----
 tests/test_junction_scoping.py                 | 204 ++++++++++++++++---------
 tests/test_pipeline2_compose.py                |  74 ++++-----
 tests/test_pipeline2_gateway_routing.py        |  48 +++---
 tests/test_unit_creator_fk_references.py       |  21 +--
 tests/test_unit_enum_blank.py                  |  10 +-
 tests/test_unit_junction_scoping.py            |  21 ++-
 11 files changed, 338 insertions(+), 277 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)